### PR TITLE
feat: expose only metrics without forced soon count

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -69,7 +69,89 @@ docker run -d \
 
 L’UI est localisée en anglais, français, espagnol, allemand et italien. La langue se choisit dans l’en-tête ou via `?lang=xx`.
 
+## Exporter des métriques vers Prometheus
+
+Les métriques sont exposées sur l’endpoint `/metrics`.
+
+- vcv_cache_size
+- vcv_certificate_expiry_timestamp_seconds{serial_number, common_name, status}
+- vcv_certificate_exporter_last_scrape_success
+- vcv_certificates_expired_count
+- vcv_certificates_last_fetch_timestamp_seconds
+- vcv_certificates_total{status}
+- vcv_vault_connected
+
+Pour configurer le scraping côté Prometheus :
+
+```yaml
+scrape_configs:
+  - job_name: vcv
+    static_configs:
+      - targets: ['localhost:52000']
+    metrics_path: /metrics
+```
+
+Example scrape output (truncated):
+
+```bash
+$ curl -v http://localhost:52000/metrics
+...
+# HELP vcv_cache_size Number of items currently cached
+# TYPE vcv_cache_size gauge
+vcv_cache_size 0
+# HELP vcv_certificate_expiry_timestamp_seconds Certificate expiration timestamp in seconds since epoch
+# TYPE vcv_certificate_expiry_timestamp_seconds gauge
+vcv_certificate_expiry_timestamp_seconds{common_name="api.internal",serial_number="52:e3:c0:23:ba:f4:51:ae:1b:59:24:4a:d1:03:e1:a7:8a:96:a7:80",status="active"} 1.767710142e+09
+vcv_certificate_expiry_timestamp_seconds{common_name="example.internal",serial_number="35:1b:ff:d3:e2:f3:53:14:b1:7f:9e:d3:77:a6:25:72:a2:63:15:99",status="active"} 1.767710142e+09
+vcv_certificate_expiry_timestamp_seconds{common_name="expired.internal",serial_number="74:5a:ed:76:98:b1:c8:e3:d7:a5:bb:a2:67:7f:f6:4f:2a:31:48:18",status="active"} 1.765118144e+09
+vcv_certificate_expiry_timestamp_seconds{common_name="expiring-soon.internal",serial_number="36:c6:0b:ef:2c:a5:2f:08:89:6a:13:fe:2a:9e:43:84:38:a4:a9:af",status="active"} 1.765204542e+09
+vcv_certificate_expiry_timestamp_seconds{common_name="expiring-week.internal",serial_number="47:c9:8f:71:2a:d7:14:49:96:64:af:d6:15:ec:e9:86:a6:59:cf:26",status="active"} 1.765722942e+09
+vcv_certificate_expiry_timestamp_seconds{common_name="revoked.internal",serial_number="2d:08:41:de:10:5a:21:0e:63:0d:5d:8e:f9:4e:ce:4b:7b:31:2e:2d",status="revoked"} 1.767710145e+09
+vcv_certificate_expiry_timestamp_seconds{common_name="vcv.local",serial_number="48:88:7a:6a:65:85:85:8b:0a:2a:12:7f:a7:6f:dc:62:3a:f2:7a:ba",status="active"} 1.796654141e+09
+# HELP vcv_certificate_exporter_last_scrape_success Whether the last scrape succeeded (1) or failed (0)
+# TYPE vcv_certificate_exporter_last_scrape_success gauge
+vcv_certificate_exporter_last_scrape_success 1
+# HELP vcv_certificates_expired_count Number of expired certificates
+# TYPE vcv_certificates_expired_count gauge
+vcv_certificates_expired_count 1
+# HELP vcv_certificates_expires_soon_count Number of certificates expiring soon within threshold window
+# TYPE vcv_certificates_expires_soon_count gauge
+vcv_certificates_expires_soon_count 4
+# HELP vcv_certificates_last_fetch_timestamp_seconds Timestamp of last successful certificates fetch
+# TYPE vcv_certificates_last_fetch_timestamp_seconds gauge
+vcv_certificates_last_fetch_timestamp_seconds 1.765118171e+09
+# HELP vcv_certificates_total Total certificates grouped by status
+# TYPE vcv_certificates_total gauge
+vcv_certificates_total{status="active"} 6
+vcv_certificates_total{status="revoked"} 1
+# HELP vcv_vault_connected Vault connection status (1=connected,0=disconnected)
+# TYPE vcv_vault_connected gauge
+vcv_vault_connected 1
+```
+
+Si vous utilisez AlertManager, vous pouvez créer des alertes à partir de ces métriques. Par exemple, en ne vous basant que sur le timestamp d’expiration et les compteurs génériques :
+
+```yaml
+- alert: VCVExpiredCerts
+  expr: vcv_certificates_expired_count > 0
+
+- alert: VCVExpiringSoon_14d
+  expr: (vcv_certificate_expiry_timestamp_seconds - time()) / 86400 < 14
+
+- alert: VCVStaleData
+  expr: time() - vcv_certificates_last_fetch_timestamp_seconds > 3600
+
+- alert: VCVVaultDown
+  expr: vcv_vault_connected == 0
+```
+
+Vous pouvez adapter librement la fenêtre « bientôt » (ici 14 jours) directement dans vos requêtes PromQL, sans modifier l’exporter.
+
 ## Pour aller plus loin
 
 - Documentation technique : [app/README.md](app/README.md)
 - Version anglaise : [README.md](README.md)
+
+## Picture of the app
+
+<img width="3024" height="2807" alt="VaultCertsViewer" src="https://github.com/user-attachments/assets/8b097046-d921-4b1d-a270-f86e8be5fc36" />

--- a/app/internal/metrics/certificate_collector.go
+++ b/app/internal/metrics/certificate_collector.go
@@ -10,33 +10,26 @@ import (
 	"vcv/internal/vault"
 )
 
-const expirySoonWindowDays int = 30
-
 var (
 	cacheSizeDesc             = prometheus.NewDesc("vcv_cache_size", "Number of items currently cached", nil, nil)
 	certificatesLastFetchDesc = prometheus.NewDesc("vcv_certificates_last_fetch_timestamp_seconds", "Timestamp of last successful certificates fetch", nil, nil)
 	certificatesTotalDesc     = prometheus.NewDesc("vcv_certificates_total", "Total certificates grouped by status", []string{"status"}, nil)
 	expiredCountDesc          = prometheus.NewDesc("vcv_certificates_expired_count", "Number of expired certificates", nil, nil)
-	expiresInDesc             = prometheus.NewDesc("vcv_certificate_expires_in_seconds", "Seconds until certificate expiration (zero when expired)", []string{"serial_number", "common_name", "status"}, nil)
-	expiresSoonCountDesc      = prometheus.NewDesc("vcv_certificates_expires_soon_count", "Number of certificates expiring soon within threshold window", nil, nil)
-	expiresSoonDesc           = prometheus.NewDesc("vcv_certificate_expires_soon", "Certificate expires soon within threshold window (1=true,0=false)", []string{"serial_number", "common_name"}, nil)
 	expiryTimestampDesc       = prometheus.NewDesc("vcv_certificate_expiry_timestamp_seconds", "Certificate expiration timestamp in seconds since epoch", []string{"serial_number", "common_name", "status"}, nil)
 	lastScrapeSuccessDesc     = prometheus.NewDesc("vcv_certificate_exporter_last_scrape_success", "Whether the last scrape succeeded (1) or failed (0)", nil, nil)
 	vaultConnectedDesc        = prometheus.NewDesc("vcv_vault_connected", "Vault connection status (1=connected,0=disconnected)", nil, nil)
 )
 
 type certificateCollector struct {
-	vaultClient      vault.Client
-	expirySoonWindow time.Duration
-	now              func() time.Time
+	vaultClient vault.Client
+	now         func() time.Time
 }
 
 // NewCertificateCollector returns a Prometheus collector exposing certificate inventory and expiry status.
 func NewCertificateCollector(vaultClient vault.Client) prometheus.Collector {
 	return &certificateCollector{
-		vaultClient:      vaultClient,
-		expirySoonWindow: time.Duration(expirySoonWindowDays) * 24 * time.Hour,
-		now:              time.Now,
+		vaultClient: vaultClient,
+		now:         time.Now,
 	}
 }
 
@@ -45,9 +38,6 @@ func (collector *certificateCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- certificatesLastFetchDesc
 	ch <- certificatesTotalDesc
 	ch <- expiredCountDesc
-	ch <- expiresInDesc
-	ch <- expiresSoonCountDesc
-	ch <- expiresSoonDesc
 	ch <- expiryTimestampDesc
 	ch <- lastScrapeSuccessDesc
 	ch <- vaultConnectedDesc
@@ -70,7 +60,6 @@ func (collector *certificateCollector) Collect(ch chan<- prometheus.Metric) {
 
 	activeCount, revokedCount := collector.countStatuses(certificates)
 	expiredCount := collector.countExpired(certificates, now)
-	expiresSoonCount := collector.countExpiresSoon(certificates, now)
 	cacheSize := collector.getCacheSize()
 
 	ch <- prometheus.MustNewConstMetric(cacheSizeDesc, prometheus.GaugeValue, float64(cacheSize))
@@ -78,7 +67,6 @@ func (collector *certificateCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(certificatesTotalDesc, prometheus.GaugeValue, float64(activeCount), "active")
 	ch <- prometheus.MustNewConstMetric(certificatesTotalDesc, prometheus.GaugeValue, float64(revokedCount), "revoked")
 	ch <- prometheus.MustNewConstMetric(expiredCountDesc, prometheus.GaugeValue, float64(expiredCount))
-	ch <- prometheus.MustNewConstMetric(expiresSoonCountDesc, prometheus.GaugeValue, float64(expiresSoonCount))
 	ch <- prometheus.MustNewConstMetric(vaultConnectedDesc, prometheus.GaugeValue, vaultConnected)
 	collector.emitCertificateMetrics(ch, certificates, now)
 }
@@ -110,16 +98,6 @@ func (collector *certificateCollector) countExpired(certificates []certs.Certifi
 	return count
 }
 
-func (collector *certificateCollector) countExpiresSoon(certificates []certs.Certificate, now time.Time) int {
-	count := 0
-	for _, certificate := range certificates {
-		if collector.expiresSoonValue(certificate, now) == 1 {
-			count++
-		}
-	}
-	return count
-}
-
 func (collector *certificateCollector) getCacheSize() int {
 	// Try to access cache via reflection or interface if available
 	// For now, return 0 as cache size is not exposed by vault.Client interface
@@ -130,28 +108,8 @@ func (collector *certificateCollector) emitCertificateMetrics(ch chan<- promethe
 	for _, certificate := range certificates {
 		status := collector.statusLabel(certificate.Revoked)
 		expiryTimestamp := float64(certificate.ExpiresAt.Unix())
-		secondsToExpiry := certificate.ExpiresAt.Sub(now).Seconds()
-		if secondsToExpiry < 0 {
-			secondsToExpiry = 0
-		}
-		expiresSoon := collector.expiresSoonValue(certificate, now)
 		ch <- prometheus.MustNewConstMetric(expiryTimestampDesc, prometheus.GaugeValue, expiryTimestamp, certificate.ID, certificate.CommonName, status)
-		ch <- prometheus.MustNewConstMetric(expiresInDesc, prometheus.GaugeValue, secondsToExpiry, certificate.ID, certificate.CommonName, status)
-		ch <- prometheus.MustNewConstMetric(expiresSoonDesc, prometheus.GaugeValue, expiresSoon, certificate.ID, certificate.CommonName)
 	}
-}
-
-func (collector *certificateCollector) expiresSoonValue(certificate certs.Certificate, now time.Time) float64 {
-	if certificate.Revoked {
-		return 0
-	}
-	if certificate.ExpiresAt.Before(now) {
-		return 0
-	}
-	if certificate.ExpiresAt.Sub(now) <= collector.expirySoonWindow {
-		return 1
-	}
-	return 0
 }
 
 func (collector *certificateCollector) statusLabel(revoked bool) string {

--- a/app/internal/metrics/certificate_collector_test.go
+++ b/app/internal/metrics/certificate_collector_test.go
@@ -60,15 +60,15 @@ func TestCollector_SuccessMetrics(t *testing.T) {
 	assertGauge(t, registry, "vcv_certificate_exporter_last_scrape_success", nil, 1.0)
 	assertGauge(t, registry, "vcv_vault_connected", nil, 1.0)
 	assertGauge(t, registry, "vcv_certificates_expired_count", nil, 1.0)
-	assertGauge(t, registry, "vcv_certificates_expires_soon_count", nil, 1.0)
 	assertGauge(t, registry, "vcv_certificates_total", map[string]string{"status": "active"}, 3.0)
 	assertGauge(t, registry, "vcv_certificates_total", map[string]string{"status": "revoked"}, 1.0)
 
-	// Per-certificate expiry flag for the "soon" cert
-	assertGauge(t, registry, "vcv_certificate_expires_soon", map[string]string{
+	// Per-certificate expiry timestamp for the "soon" cert
+	assertGauge(t, registry, "vcv_certificate_expiry_timestamp_seconds", map[string]string{
 		"serial_number": "active-soon",
 		"common_name":   "soon",
-	}, 1.0)
+		"status":        "active",
+	}, float64(now.Add(10*24*time.Hour).Unix()))
 
 	mockVault.AssertExpectations(t)
 }


### PR DESCRIPTION
Simplify Prometheus metrics by removing redundant expiry calculations

Remove vcv_certificate_expires_in_seconds, vcv_certificate_expires_soon, and vcv_certificates_expires_soon_count metrics in favor of using vcv_certificate_expiry_timestamp_seconds with PromQL calculations. Update README documentation in both English and French with AlertManager examples showing how to calculate expiry windows directly in PromQL queries, and adjust example output to reflect simplified metric set.