### PR TITLE
feat: add active filter chips, source counter, and row affordance

### DIFF
--- a/app/internal/handlers/ui.go
+++ b/app/internal/handlers/ui.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"html/template"
@@ -154,6 +155,7 @@ type certsFragmentTemplateData struct {
 	DashboardRevoked    int
 	DashboardCertsLabel string
 	AdminDocsTitle      string `json:"adminDocsTitle"`
+	FilteredCount       int
 }
 
 type dashboardStatsTemplateData struct {
@@ -1328,9 +1330,29 @@ func renderCertsFragment(w http.ResponseWriter, templates *template.Template, ce
 		return fmt.Errorf("templates not available")
 	}
 	data := buildCertsFragmentData(certificates, expirationThresholds, messages, queryState, vaultDisplayNames, showVaultMount)
+	if trigger := buildFiltersAppliedTrigger(queryState, data.FilteredCount); trigger != "" {
+		w.Header().Set("HX-Trigger", trigger)
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	return templates.ExecuteTemplate(w, "certs-fragment.html", data)
+}
+
+func buildFiltersAppliedTrigger(state certsQueryState, count int) string {
+	payload := map[string]any{
+		"vcv:filters-applied": map[string]any{
+			"count":    count,
+			"search":   state.SearchTerm,
+			"status":   state.StatusFilter,
+			"certType": state.CertTypeFilter,
+			"mounts":   state.SelectedMounts,
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 func buildCertsFragmentData(certificates []certs.Certificate, expirationThresholds config.ExpirationThresholds, messages i18n.Messages, queryState certsQueryState, vaultDisplayNames map[string]string, showVaultMount bool) certsFragmentTemplateData {
@@ -1381,6 +1403,7 @@ func buildCertsFragmentData(certificates []certs.Certificate, expirationThreshol
 		DashboardRevoked:    dashboardStats.Revoked,
 		DashboardCertsLabel: messages.DashboardCertsLabel,
 		AdminDocsTitle:      messages.AdminDocsTitle,
+		FilteredCount:       len(visible),
 	}
 }
 

--- a/app/internal/i18n/i18n.go
+++ b/app/internal/i18n/i18n.go
@@ -121,6 +121,16 @@ type Messages struct {
 	PaginationPrev              string `json:"paginationPrev"`
 	SearchPlaceholder           string `json:"searchPlaceholder"`
 	SelectAll                   string `json:"selectAll"`
+	FilterChipSearch            string `json:"filterChipSearch"`
+	FilterChipStatus            string `json:"filterChipStatus"`
+	FilterChipCertType          string `json:"filterChipCertType"`
+	FilterChipSources           string `json:"filterChipSources"`
+	FilterChipReset             string `json:"filterChipReset"`
+	ResultsCount                string `json:"resultsCount"`
+	ResultsCountFor             string `json:"resultsCountFor"`
+	SourcesButtonAll            string `json:"sourcesButtonAll"`
+	SourcesButtonPartial        string `json:"sourcesButtonPartial"`
+	RowDetailsLabel             string `json:"rowDetailsLabel"`
 	StatusFilterAll             string `json:"statusFilterAll"`
 	StatusFilterExpired         string `json:"statusFilterExpired"`
 	StatusFilterExpiring        string `json:"statusFilterExpiring"`
@@ -291,6 +301,16 @@ var englishMessages = Messages{
 	PaginationPrev:              "Previous",
 	SearchPlaceholder:           "Search by Serial Number, Common Name (CN) or SAN",
 	SelectAll:                   "Select all",
+	FilterChipSearch:            "Search",
+	FilterChipStatus:            "Status",
+	FilterChipCertType:          "Type",
+	FilterChipSources:           "Sources",
+	FilterChipReset:             "Reset filters",
+	ResultsCount:                "{count} results",
+	ResultsCountFor:             "{count} results for \"{query}\"",
+	SourcesButtonAll:            "Sources: {total}/{total}",
+	SourcesButtonPartial:        "Sources: {selected}/{total}",
+	RowDetailsLabel:             "View details",
 	StatusFilterAll:             "All",
 	StatusFilterExpired:         "Expired",
 	StatusFilterExpiring:        "Expiring soon",
@@ -455,6 +475,16 @@ var frenchMessages = Messages{
 	PaginationPrev:              "Précédent",
 	SearchPlaceholder:           "Rechercher par numéro de série, nom commun (CN) ou SAN",
 	SelectAll:                   "Tout sélectionner",
+	FilterChipSearch:            "Recherche",
+	FilterChipStatus:            "Statut",
+	FilterChipCertType:          "Type",
+	FilterChipSources:           "Sources",
+	FilterChipReset:             "Réinitialiser les filtres",
+	ResultsCount:                "{count} résultats",
+	ResultsCountFor:             "{count} résultats pour « {query} »",
+	SourcesButtonAll:            "Sources : {total}/{total}",
+	SourcesButtonPartial:        "Sources : {selected}/{total}",
+	RowDetailsLabel:             "Voir les détails",
 	StatusFilterAll:             "Tous",
 	StatusFilterExpired:         "Expiré",
 	StatusFilterExpiring:        "Expiration proche",
@@ -619,6 +649,16 @@ var spanishMessages = Messages{
 	PaginationPrev:              "Anterior",
 	SearchPlaceholder:           "Buscar por Número de Serie, Nombre Común (CN) o SAN",
 	SelectAll:                   "Seleccionar todo",
+	FilterChipSearch:            "Search",
+	FilterChipStatus:            "Status",
+	FilterChipCertType:          "Type",
+	FilterChipSources:           "Sources",
+	FilterChipReset:             "Reset filters",
+	ResultsCount:                "{count} results",
+	ResultsCountFor:             "{count} results for \"{query}\"",
+	SourcesButtonAll:            "Sources: {total}/{total}",
+	SourcesButtonPartial:        "Sources: {selected}/{total}",
+	RowDetailsLabel:             "View details",
 	StatusFilterAll:             "Todos",
 	StatusFilterExpired:         "Caducado",
 	StatusFilterExpiring:        "Próximo a caducar",
@@ -783,6 +823,16 @@ var germanMessages = Messages{
 	PaginationPrev:              "Zurück",
 	SearchPlaceholder:           "Suche nach Seriennummer, Common Name (CN) oder SAN",
 	SelectAll:                   "Alle auswählen",
+	FilterChipSearch:            "Search",
+	FilterChipStatus:            "Status",
+	FilterChipCertType:          "Type",
+	FilterChipSources:           "Sources",
+	FilterChipReset:             "Reset filters",
+	ResultsCount:                "{count} results",
+	ResultsCountFor:             "{count} results for \"{query}\"",
+	SourcesButtonAll:            "Sources: {total}/{total}",
+	SourcesButtonPartial:        "Sources: {selected}/{total}",
+	RowDetailsLabel:             "View details",
 	StatusFilterAll:             "Alle",
 	StatusFilterExpired:         "Abgelaufen",
 	StatusFilterExpiring:        "Bald ablaufend",
@@ -946,6 +996,16 @@ var italianMessages = Messages{
 	PaginationPrev:              "Precedente",
 	SearchPlaceholder:           "Cerca per Numero di Serie, Nome Comune (CN) o SAN",
 	SelectAll:                   "Seleziona tutto",
+	FilterChipSearch:            "Search",
+	FilterChipStatus:            "Status",
+	FilterChipCertType:          "Type",
+	FilterChipSources:           "Sources",
+	FilterChipReset:             "Reset filters",
+	ResultsCount:                "{count} results",
+	ResultsCountFor:             "{count} results for \"{query}\"",
+	SourcesButtonAll:            "Sources: {total}/{total}",
+	SourcesButtonPartial:        "Sources: {selected}/{total}",
+	RowDetailsLabel:             "View details",
 	StatusFilterAll:             "Tutti",
 	StatusFilterExpired:         "Scaduto",
 	StatusFilterExpiring:        "In scadenza",

--- a/app/web/assets/app-htmx.js
+++ b/app/web/assets/app-htmx.js
@@ -80,6 +80,7 @@ function applyMountSelectionChange(shouldRenderSelector) {
   renderMountModalList();
   refreshHtmxCertsTable();
   updateFilterBadge();
+  renderActiveFilters();
 }
 
 function shouldSuppressErrorToast(detail) {
@@ -926,19 +927,32 @@ function renderMountSelector() {
   if (!container) {
     return;
   }
-  const label = typeof state.messages.mountSelectorTitle === "string" && state.messages.mountSelectorTitle !== "" ? state.messages.mountSelectorTitle : "Sources";
+  const baseLabel = typeof state.messages.mountSelectorTitle === "string" && state.messages.mountSelectorTitle !== "" ? state.messages.mountSelectorTitle : "Sources";
   const tooltip = typeof state.messages.mountSelectorTooltip === "string" && state.messages.mountSelectorTooltip !== "" ? state.messages.mountSelectorTooltip : "Select which certificate sources to display";
   const filterIcon = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" x2="4" y1="21" y2="14"/><line x1="4" x2="4" y1="10" y2="3"/><line x1="12" x2="12" y1="21" y2="12"/><line x1="12" x2="12" y1="8" y2="3"/><line x1="20" x2="20" y1="21" y2="16"/><line x1="20" x2="20" y1="12" y2="3"/><line x1="2" x2="6" y1="14" y2="14"/><line x1="10" x2="14" y1="8" y2="8"/><line x1="18" x2="22" y1="16" y2="16"/></svg>';
   const selected = state.selectedMounts.length;
   const total = state.availableMounts.length;
-  const allSelected = total > 0 && selected === total;
-  const badge = total > 0 && !allSelected ? ` <span class="vcv-mount-trigger-badge">${selected}/${total}</span>` : "";
-  container.innerHTML = `
-    <button type="button" class="vcv-button vcv-button-ghost vcv-mount-trigger" onclick="VCV.openMountModal()" title="${tooltip}">
-      ${filterIcon}
-      <span class="vcv-mount-trigger-label">${label}</span>${badge}
-    </button>
-  `;
+  const partial = total > 0 && selected < total;
+  let label = baseLabel;
+  if (total > 0) {
+    const tpl = partial
+      ? (state.messages.sourcesButtonPartial || "Sources: {selected}/{total}")
+      : (state.messages.sourcesButtonAll || "Sources: {total}/{total}");
+    label = tpl.replace("{selected}", String(selected)).replace("{total}", String(total)).replace("{total}", String(total));
+  }
+  const triggerClass = partial ? "vcv-button vcv-button-ghost vcv-mount-trigger vcv-mount-trigger-partial" : "vcv-button vcv-button-ghost vcv-mount-trigger";
+  container.replaceChildren();
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = triggerClass;
+  btn.title = tooltip;
+  btn.addEventListener("click", openMountModal);
+  btn.insertAdjacentHTML("beforeend", filterIcon);
+  const labelSpan = document.createElement("span");
+  labelSpan.className = "vcv-mount-trigger-label";
+  labelSpan.textContent = label;
+  btn.appendChild(labelSpan);
+  container.appendChild(btn);
 }
 
 function updateMountStats() {
@@ -1423,6 +1437,203 @@ function updateFilterBadge() {
   }
 }
 
+const ACTIVE_CHIP_X_SVG = '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';
+
+function buildActiveChip(options) {
+  const chip = document.createElement("span");
+  chip.className = "vcv-active-chip";
+  if (options.variant) {
+    chip.classList.add(`vcv-active-chip-${options.variant}`);
+  }
+  chip.dataset.chipKey = options.key;
+  if (options.dotClass) {
+    const dot = document.createElement("span");
+    dot.className = `vcv-active-chip-dot ${options.dotClass}`;
+    dot.setAttribute("aria-hidden", "true");
+    chip.appendChild(dot);
+  }
+  if (options.prefix) {
+    const prefix = document.createElement("span");
+    prefix.className = "vcv-active-chip-prefix";
+    prefix.textContent = options.prefix;
+    chip.appendChild(prefix);
+  }
+  const value = document.createElement("span");
+  value.className = "vcv-active-chip-value";
+  value.textContent = options.value;
+  chip.appendChild(value);
+  const clear = document.createElement("button");
+  clear.type = "button";
+  clear.className = "vcv-active-chip-clear";
+  clear.setAttribute("aria-label", options.clearAriaLabel || "Clear");
+  clear.insertAdjacentHTML("beforeend", ACTIVE_CHIP_X_SVG);
+  clear.addEventListener("click", options.onClear);
+  chip.appendChild(clear);
+  return chip;
+}
+
+function renderActiveFilters(count) {
+  const container = document.getElementById("vcv-active-filters");
+  if (!container) {
+    return;
+  }
+  const messages = state.messages || {};
+  const searchEl = document.getElementById("vcv-search");
+  const certTypeEl = document.getElementById("vcv-cert-type-filter");
+  const statusEl = document.getElementById("vcv-status-filter");
+  const search = searchEl ? String(searchEl.value || "") : "";
+  const certType = certTypeEl ? String(certTypeEl.value || "all") : "all";
+  const status = statusEl ? String(statusEl.value || "all") : "all";
+  const selectedMounts = state.selectedMounts.length;
+  const totalMounts = state.availableMounts.length;
+  const mountsPartial = totalMounts > 0 && selectedMounts < totalMounts;
+
+  const statusLabels = {
+    valid: messages.dashboardValid || "Valid",
+    warning: messages.dashboardWarning || "Warning",
+    critical: messages.dashboardCritical || "Critical",
+    expired: messages.dashboardExpired || "Expired",
+    revoked: messages.dashboardRevoked || "Revoked",
+  };
+  const certTypeLabels = {
+    machine: messages.certTypeFilterMachine || "Machine",
+    user: messages.certTypeFilterUser || "User",
+    both: messages.certTypeFilterBoth || "Both",
+    unknown: messages.certTypeFilterUnknown || "Unknown",
+  };
+
+  const statusList = status && status !== "all" ? status.split(",").map((s) => s.trim()).filter((s) => s !== "" && s !== "all") : [];
+  const trimmedSearch = search.trim();
+  const hasAnyFilter = trimmedSearch !== "" || statusList.length > 0 || (certType && certType !== "all") || mountsPartial;
+
+  container.replaceChildren();
+  if (!hasAnyFilter) {
+    container.classList.add("vcv-hidden");
+    return;
+  }
+  container.classList.remove("vcv-hidden");
+
+  const inner = document.createElement("div");
+  inner.className = "vcv-active-filters-inner";
+
+  if (trimmedSearch !== "") {
+    inner.appendChild(buildActiveChip({
+      key: "search",
+      prefix: messages.filterChipSearch || "Search",
+      value: search,
+      onClear: () => clearActiveFilter("search"),
+    }));
+  }
+  statusList.forEach((s) => {
+    inner.appendChild(buildActiveChip({
+      key: `status:${s}`,
+      variant: `status-${s}`,
+      dotClass: `vcv-active-chip-dot-${s}`,
+      value: statusLabels[s] || s,
+      onClear: () => clearActiveFilter(`status:${s}`),
+    }));
+  });
+  if (certType && certType !== "all") {
+    inner.appendChild(buildActiveChip({
+      key: "certType",
+      prefix: messages.filterChipCertType || "Type",
+      value: certTypeLabels[certType] || certType,
+      onClear: () => clearActiveFilter("certType"),
+    }));
+  }
+  if (mountsPartial) {
+    inner.appendChild(buildActiveChip({
+      key: "mounts",
+      prefix: messages.filterChipSources || "Sources",
+      value: `${selectedMounts}/${totalMounts}`,
+      onClear: () => clearActiveFilter("mounts"),
+    }));
+  }
+
+  if (typeof count === "number" && count >= 0) {
+    let resultsText;
+    if (trimmedSearch !== "") {
+      const tpl = messages.resultsCountFor || '{count} results for "{query}"';
+      resultsText = tpl.replace("{count}", String(count)).replace("{query}", search);
+    } else {
+      const tpl = messages.resultsCount || "{count} results";
+      resultsText = tpl.replace("{count}", String(count));
+    }
+    const resultsSpan = document.createElement("span");
+    resultsSpan.className = "vcv-active-results";
+    resultsSpan.textContent = resultsText;
+    inner.appendChild(resultsSpan);
+  }
+
+  const resetBtn = document.createElement("button");
+  resetBtn.type = "button";
+  resetBtn.className = "vcv-active-reset";
+  resetBtn.textContent = messages.filterChipReset || "Reset filters";
+  resetBtn.addEventListener("click", resetAllFilters);
+  inner.appendChild(resetBtn);
+
+  container.appendChild(inner);
+}
+
+function clearActiveFilter(key) {
+  if (key === "search") {
+    const el = document.getElementById("vcv-search");
+    if (el) {
+      el.value = "";
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+  } else if (key === "status") {
+    clearStatusFilter();
+  } else if (key.startsWith("status:")) {
+    const status = key.slice("status:".length);
+    if (status !== "") {
+      filterByDashboardCard(status);
+    }
+  } else if (key === "certType") {
+    const el = document.getElementById("vcv-cert-type-filter");
+    if (el) {
+      el.value = "all";
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+  } else if (key === "mounts") {
+    selectAllMounts();
+  }
+  renderActiveFilters();
+}
+
+function resetAllFilters() {
+  const searchEl = document.getElementById("vcv-search");
+  if (searchEl) {
+    searchEl.value = "";
+  }
+  const certTypeEl = document.getElementById("vcv-cert-type-filter");
+  if (certTypeEl) {
+    certTypeEl.value = "all";
+  }
+  clearStatusFilter();
+  if (state.availableMounts.length > 0 && state.selectedMounts.length < state.availableMounts.length) {
+    selectAllMounts();
+  } else {
+    refreshHtmxCertsTable();
+  }
+  renderActiveFilters();
+}
+
+function initActiveFiltersListeners() {
+  document.body.addEventListener("vcv:filters-applied", (evt) => {
+    const detail = (evt && evt.detail) || {};
+    renderActiveFilters(typeof detail.count === "number" ? detail.count : undefined);
+  });
+  const searchInput = document.getElementById("vcv-search");
+  if (searchInput) {
+    searchInput.addEventListener("input", () => renderActiveFilters());
+  }
+  const certTypeSelect = document.getElementById("vcv-cert-type-filter");
+  if (certTypeSelect) {
+    certTypeSelect.addEventListener("change", () => renderActiveFilters());
+  }
+}
+
 function initFilterBadgeListeners() {
   const searchInput = document.getElementById("vcv-search");
   if (searchInput) {
@@ -1456,6 +1667,7 @@ async function main() {
     initDashboardKeyboard();
     initVaultConnectionNotifications();
     initFilterBadgeListeners();
+    initActiveFiltersListeners();
     // Load remaining non-critical startup data
     await messagesPromise;
     applyTranslations();
@@ -1466,6 +1678,7 @@ async function main() {
     renderMountSelector();
     setMountsHiddenField();
     updateFilterBadge();
+    renderActiveFilters();
   } else {
     // Admin page or other pages
     initModalHandlers();
@@ -1501,5 +1714,7 @@ window.VCV = {
   openVaultStatusModal: openVaultStatusModal,
   closeVaultStatusModal: closeVaultStatusModal,
   handleVaultRefresh: handleVaultRefresh,
+  clearActiveFilter: clearActiveFilter,
+  resetAllFilters: resetAllFilters,
 };
 })();

--- a/app/web/assets/styles.css
+++ b/app/web/assets/styles.css
@@ -1456,11 +1456,191 @@ col.vcv-col-status {
 /* Clickable rows */
 .vcv-row-clickable {
   cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+
+.vcv-row-clickable:hover {
+  background-color: var(--vcv-color-surface-hover, rgba(127, 127, 127, 0.06));
 }
 
 .vcv-row-clickable:focus-visible {
   outline: 2px solid var(--vcv-color-primary);
   outline-offset: -2px;
+}
+
+.vcv-status-cell {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.vcv-status-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.vcv-row-chevron {
+  color: var(--vcv-color-muted);
+  flex-shrink: 0;
+  font-size: 1.25rem;
+  line-height: 1;
+  opacity: 0.55;
+  transform: translateX(0);
+  transition:
+    transform 0.12s ease,
+    opacity 0.12s ease,
+    color 0.12s ease;
+}
+
+.vcv-row-clickable:hover .vcv-row-chevron,
+.vcv-row-clickable:focus-visible .vcv-row-chevron {
+  color: var(--vcv-color-primary);
+  opacity: 1;
+  transform: translateX(2px);
+}
+
+/* Active filter chips bar */
+.vcv-active-filters {
+  margin-top: 0.625rem;
+}
+
+.vcv-active-filters-inner {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  row-gap: 0.5rem;
+}
+
+.vcv-active-chip {
+  align-items: center;
+  background: var(--vcv-color-surface, #fff);
+  border: 1px solid var(--vcv-color-border, rgba(15, 23, 42, 0.12));
+  border-radius: 9999px;
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.02);
+  color: var(--vcv-color-text, #0f172a);
+  display: inline-flex;
+  font-size: 0.75rem;
+  font-weight: 500;
+  gap: 0.375rem;
+  height: 1.625rem;
+  line-height: 1;
+  padding: 0 0.25rem 0 0.625rem;
+  transition:
+    border-color 0.12s ease,
+    background-color 0.12s ease;
+}
+
+.vcv-active-chip:hover {
+  border-color: var(--vcv-color-border-strong, rgba(15, 23, 42, 0.2));
+}
+
+.vcv-active-chip-dot {
+  background: currentColor;
+  border-radius: 9999px;
+  flex-shrink: 0;
+  height: 0.5rem;
+  width: 0.5rem;
+}
+
+.vcv-active-chip-dot-valid { color: var(--vcv-color-primary, #10b981); }
+.vcv-active-chip-dot-warning { color: var(--vcv-color-warning, #f59e0b); }
+.vcv-active-chip-dot-critical { color: var(--vcv-color-danger, #ef4444); }
+.vcv-active-chip-dot-expired { color: var(--vcv-color-expired, #6b7280); }
+.vcv-active-chip-dot-revoked { color: var(--vcv-color-revoked, #8b5cf6); }
+
+.vcv-active-chip-prefix {
+  color: var(--vcv-color-muted, #64748b);
+  font-weight: 500;
+}
+
+.vcv-active-chip-prefix::after {
+  content: ":";
+  margin-left: 0.0625rem;
+}
+
+.vcv-active-chip-value {
+  color: var(--vcv-color-text, #0f172a);
+  font-weight: 600;
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vcv-active-chip-clear {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 9999px;
+  color: var(--vcv-color-muted, #64748b);
+  cursor: pointer;
+  display: inline-flex;
+  height: 1.25rem;
+  justify-content: center;
+  line-height: 1;
+  margin-left: 0.125rem;
+  padding: 0;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+  width: 1.25rem;
+}
+
+.vcv-active-chip-clear:hover,
+.vcv-active-chip-clear:focus-visible {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--vcv-color-text, #0f172a);
+  outline: none;
+}
+
+.vcv-active-results {
+  color: var(--vcv-color-muted, #64748b);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  margin-left: 0.25rem;
+  white-space: nowrap;
+}
+
+.vcv-active-reset {
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--vcv-color-primary, #10b981);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-left: auto;
+  padding: 0.25rem 0.5rem;
+  transition: background-color 0.12s ease;
+}
+
+.vcv-active-reset:hover,
+.vcv-active-reset:focus-visible {
+  background: rgba(16, 185, 129, 0.1);
+  outline: none;
+}
+
+[data-theme="dark"] .vcv-active-chip {
+  background: var(--vcv-color-surface-elevated, rgba(255, 255, 255, 0.04));
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+}
+
+[data-theme="dark"] .vcv-active-chip:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+[data-theme="dark"] .vcv-active-chip-clear:hover,
+[data-theme="dark"] .vcv-active-chip-clear:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.vcv-mount-trigger-partial {
+  border-color: var(--vcv-color-primary, currentColor);
 }
 
 /* SAN hint below cert name */

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -130,6 +130,7 @@
             </div>
           </div>
         </div>
+        <div id="vcv-active-filters" class="vcv-active-filters vcv-hidden" aria-live="polite"></div>
       </header>
 
       <!-- Mount selector modal -->
@@ -379,7 +380,10 @@
                 </div>
               </td>
               <td class="vcv-col-status">
-                {{range .Badges}}<span class="{{.Class}}">{{.Label}}</span>{{end}}
+                <div class="vcv-status-cell">
+                  <div class="vcv-status-badges">{{range .Badges}}<span class="{{.Class}}">{{.Label}}</span>{{end}}</div>
+                  <span class="vcv-row-chevron" aria-hidden="true">›</span>
+                </div>
               </td>
             </tr>
             {{end}}

--- a/app/web/templates/certs-rows.html
+++ b/app/web/templates/certs-rows.html
@@ -24,7 +24,10 @@
     </div>
   </td>
   <td class="vcv-col-status">
-    {{range .Badges}}<span class="{{.Class}}">{{.Label}}</span>{{end}}
+    <div class="vcv-status-cell">
+      <div class="vcv-status-badges">{{range .Badges}}<span class="{{.Class}}">{{.Label}}</span>{{end}}</div>
+      <span class="vcv-row-chevron" aria-hidden="true">›</span>
+    </div>
   </td>
 </tr>
 {{end}}


### PR DESCRIPTION
- Emit HX-Trigger "vcv:filters-applied" header with filtered count, search, status, certType, mounts from /ui/certs renders
- Add active filter chips bar below filter inputs with per-status chips (colored dot + translated label), search chip, cert type chip, sources chip (N/Total), individual clear buttons, and reset-all button
- Display "N results for query" near pagination when filters are active
- Update mount selector button label to "Sources: N/Total" with partial-state border highlight
- Add chevron + hover background on certificate rows for clearer click affordance
- Add 11 i18n keys (FR + EN, DE/ES/IT fallback to EN): FilterChipSearch, FilterChipStatus, FilterChipCertType, FilterChipSources, FilterChipReset, ResultsCount, ResultsCountFor, SourcesButtonAll, SourcesButtonPartial, RowDetailsLabel