### PR TITLE
Update config.go

### DIFF
--- a/app/internal/config/config.go
+++ b/app/internal/config/config.go
@@ -136,7 +136,7 @@ func Load() (Config, error) {
 
 // settingsCandidates returns the ordered list of settings file paths to try.
 func settingsCandidates() []string {
-	return []string{"settings.dev.json", "settings.prod.json", "settings.json", "./settings.json", "/app/settings.json"}
+	return []string{"settings.dev.json", "settings.prod.json", "settings.json", "./settings.json", "/app/config/settings.json"}
 }
 
 // ResolveSettingsPath returns the absolute path of the first settings file found on disk.


### PR DESCRIPTION
settings.json need place to subfolder, because settings.json has rw priveledges. After build docker imager need mount "config" folder for rw data to this file. If map settings.json as file, application cant update data