### PR TITLE
ci(release): trigger on bare semver tags + bump to 1.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write

--- a/app/internal/version/version.go
+++ b/app/internal/version/version.go
@@ -3,7 +3,7 @@ package version
 // Build information set via ldflags at compile time.
 var (
 	// Version is the semantic version of the application.
-	Version = "1.7"
+	Version = "1.8"
 )
 
 // Info returns version information as a structured map.


### PR DESCRIPTION
## Why
Release readiness check for tag `1.8` found a blocker: `release.yml` triggered only on `v*` tags, but every existing tag (1.0–1.7) is **bare** semver. Pushing `1.8` (as CLAUDE.md instructs) would not fire GoReleaser or the Docker build.

## Changes
- **release.yml**: trigger on `[0-9]+.[0-9]+` and `[0-9]+.[0-9]+.[0-9]+` (matches `1.8`, `1.6.1`). Keeps the bare-tag convention; CLAUDE.md example stays correct.
- **version.go**: bump default `Version` 1.7 → 1.8. GoReleaser injects the real version via ldflags at release; this keeps local/non-release builds honest.

## Verified locally (GoReleaser pipeline steps)
- [x] `pnpm install --frozen-lockfile` + `pnpm build` → dist OK
- [x] `go build -trimpath -ldflags "...Version=1.8" ./cmd/server` OK
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — 498 pass

## After merge
Tag the merge commit `1.8` to cut the release (workflow now fires).