### PR TITLE
ci(release): also publish image to Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/julienhmmt/vcv
+          images: |
+            ghcr.io/julienhmmt/vcv
+            jhmmt/vcv
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## What
Release `docker` job published only to **ghcr.io**. Add Docker Hub publishing so each release goes to both registries.

- Add Docker Hub login step (`docker/login-action`)
- Add `jhmmt/vcv` to the metadata `images` list alongside `ghcr.io/julienhmmt/vcv`

Same tag set applies to both: `{{version}}`, `{{major}}.{{minor}}`, `latest`.

## ⚠️ Required before tagging
Repo currently has **no action secrets**. Create these or the Docker Hub login fails:
- `DOCKERHUB_USERNAME` — Docker Hub user (e.g. `jhmmt`)
- `DOCKERHUB_TOKEN` — Docker Hub access token (Account Settings → Security → New Access Token, read+write)

ghcr.io needs nothing extra — it uses the built-in `GITHUB_TOKEN`.

## After merge
Tag the merge commit `1.8` to release to both registries.