### PR TITLE
ci(release): pin pnpm version + fix go cache path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "app/go.mod"
+          cache-dependency-path: "app/go.sum"
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Why
First real execution of `release.yml` (tag `1.8`) failed. Root cause: the **Set up pnpm** step.

```
##[error]Error: No pnpm version is specified.
```

`pnpm/action-setup@v4` infers the version from `packageManager` in package.json, but ours is nested at `app/web/frontend/package.json` (not repo root), so nothing was found and the GoReleaser job died before GoReleaser ran.

## Fix
- Pin `pnpm/action-setup` to `version: 10` (matches `lockfileVersion: "9.0"` and local 10.x)
- Set `setup-go` `cache-dependency-path: app/go.sum` — silences the non-fatal "Dependencies file is not found" cache warning and enables module caching

## After merge
Move tag `1.8` to the fixed commit and re-push so the corrected workflow runs.