### PR TITLE
ci(release): fix invalid GoReleaser before.hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ app/web/dist/*
 !app/web/dist/.gitkeep
 app/web/frontend/dist/
 .gstack/
+
+# GoReleaser output
+/dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,10 +6,8 @@ project_name: vcv
 # otherwise the binary serves an empty/stale UI (go:embed app/web/dist).
 before:
   hooks:
-    - cmd: pnpm install --frozen-lockfile
-      dir: app/web/frontend
-    - cmd: pnpm build
-      dir: app/web/frontend
+    - sh -c "cd app/web/frontend && pnpm install --frozen-lockfile"
+    - sh -c "cd app/web/frontend && pnpm build"
 
 builds:
   - id: vcv


### PR DESCRIPTION
## Why
Second release attempt failed at GoReleaser itself:
```
⨯ release failed after 0s error=yaml: unmarshal errors:
  line 9: cannot unmarshal !!map into string
  line 11: cannot unmarshal !!map into string
```
`before.hooks` used the `{cmd:, dir:}` object form, but GoReleaser v2 `before.hooks` only accepts plain command **strings**. The config had never executed before (added in the "trying goreleaser" commit).

## Fix
- Rewrite hooks as `sh -c "cd app/web/frontend && pnpm install --frozen-lockfile"` / `... && pnpm build"` so the embedded Svelte bundle builds in the right dir.
- gitignore `/dist/` (GoReleaser output).

## Validated locally (goreleaser v2.16.0)
- [x] `goreleaser check` → config valid
- [x] `goreleaser release --snapshot --clean --skip=publish` → hooks run, 6 cross-builds (linux/darwin/windows × amd64/arm64), archives + checksums, "release succeeded"

## After merge
Move tag `1.8` to the merge commit and re-push to run the full release.