### PR TITLE
ci(release): drop Docker job + improve changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   goreleaser:
@@ -44,52 +43,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ghcr.io/julienhmmt/vcv
-            jhmmt/vcv
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ./app
-          file: ./app/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,12 +41,33 @@ checksum:
   name_template: "checksums.txt"
 
 changelog:
+  use: git
   sort: asc
+  abbrev: -1
+  groups:
+    - title: "Features"
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: "Performance"
+      regexp: '^.*?perf(\(.+\))??!?:.+$'
+      order: 2
+    - title: "Refactoring"
+      regexp: '^.*?refactor(\(.+\))??!?:.+$'
+      order: 3
+    - title: "Other"
+      order: 999
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
+      - '^docs(\(.+\))?!?:'
+      - '^test(\(.+\))?!?:'
+      - '^chore(\(.+\))?!?:'
+      - '^style(\(.+\))?!?:'
+      - '^ci(\(.+\))?!?:'
+      - '^build(\(.+\))?!?:'
+      - '^Merge '
 
 release:
   github:


### PR DESCRIPTION
## Changes
**Drop the Docker job.** Images will be built/pushed from a workstation (`task docker-build`), not CI. Removed the `docker` job and the now-unused `packages: write` permission. The `goreleaser` job (archives + GitHub release) stays.

**Improve the changelog.** The 1.8 notes were a flat dump of 90 commits with full 40-char SHAs, and the old `^chore:` filters missed scoped commits like `chore(deps):`. New config:
- `use: git`, `abbrev: -1` (strips SHAs)
- `groups`: Features / Bug fixes / Performance / Refactoring / Other
- scope-aware excludes: `^docs(\(.+\))?!?:`, `test`, `chore`, `style`, `ci`, `build`, plus `^Merge `

## Validated
- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot` builds clean (changelog itself only renders against a real tag range, verified on the post-merge release run)

## After merge
Delete the existing `1.8` release, move the tag to the merge commit, re-push → clean run regenerates grouped notes (no Docker).