### PR TITLE
fix(web): use /api/config expiration thresholds in dashboard

### DIFF
--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -19,6 +19,7 @@
   import CertCard from '$lib/components/CertCard.svelte'
   import CommandPalette from '$lib/components/CommandPalette.svelte'
   import { createCertsStore } from '$lib/stores/certs.svelte'
+  import { createConfigStore } from '$lib/stores/config.svelte'
   import { createStatusStore } from '$lib/stores/status.svelte'
   import { createThemeStore } from '$lib/stores/theme.svelte'
   import { createI18nStore, setI18nContext, LANGUAGES } from '$lib/stores/i18n.svelte'
@@ -28,7 +29,6 @@
     parseCertID,
     statusBadgeClass,
     rowClassForStatus,
-    DEFAULT_THRESHOLDS,
   } from '$lib/utils/cert-status'
   import {
     matchesFilters,
@@ -48,19 +48,21 @@
 
   const i18n = setI18nContext(createI18nStore())
   const certs = createCertsStore(i18n)
+  const config = createConfigStore()
   const status = createStatusStore()
   const theme = createThemeStore()
+  const thresholds = $derived(config.thresholds)
 
   type StatusKey = 'valid' | 'warning' | 'critical' | 'expired' | 'revoked'
   const statusMeta = $derived<Record<StatusKey, { label: string; desc: string }>>({
     valid: { label: i18n.t('statusLabelValid', 'Valid'), desc: i18n.t('statusDescValid', 'All good') },
     warning: {
       label: i18n.t('statusLabelWarning', 'Warning'),
-      desc: i18n.t('statusDescWarning', '≤ {days} days', { days: DEFAULT_THRESHOLDS.warning }),
+      desc: i18n.t('statusDescWarning', '≤ {days} days', { days: thresholds.warning }),
     },
     critical: {
       label: i18n.t('statusLabelCritical', 'Critical'),
-      desc: i18n.t('statusDescCritical', '≤ {days} days', { days: DEFAULT_THRESHOLDS.critical }),
+      desc: i18n.t('statusDescCritical', '≤ {days} days', { days: thresholds.critical }),
     },
     expired: { label: i18n.t('statusLabelExpired', 'Expired'), desc: i18n.t('statusDescExpired', 'Past expiry') },
     revoked: { label: i18n.t('statusLabelRevoked', 'Revoked'), desc: i18n.t('statusDescRevoked', 'Revoked by CA') },
@@ -109,7 +111,11 @@
 
   const filtered = $derived(
     certs.certificates.filter((cert) =>
-      matchesFilters(cert, { search, statuses: statusFilters, certType: certTypeFilter, mounts: mountFilter }),
+      matchesFilters(
+        cert,
+        { search, statuses: statusFilters, certType: certTypeFilter, mounts: mountFilter },
+        thresholds,
+      ),
     ),
   )
   const sorted = $derived(sortCerts(filtered, sortKey, sortDir))
@@ -117,7 +123,7 @@
   const totalPages = $derived(Math.max(1, Math.ceil(sorted.length / pageSizeNum)))
   const safePage = $derived(Math.min(pageIndex, totalPages - 1))
   const paged = $derived(paginate(sorted, safePage, pageSize))
-  const counts = $derived(dashboardCounts(certs.certificates, DEFAULT_THRESHOLDS))
+  const counts = $derived(dashboardCounts(certs.certificates, thresholds))
   const hasActiveFilters = $derived(
     !!search || statusFilters.length > 0 || certTypeFilter !== 'all' || mountFilter !== null,
   )
@@ -190,8 +196,9 @@
   })
 
   async function load(initial = false): Promise<void> {
-    const promises = [certs.refresh(), status.refresh()]
+    const promises: Promise<void>[] = [certs.refresh(), status.refresh()]
     if (initial) {
+      promises.push(config.refresh())
       try {
         await Promise.all(promises)
       } finally {
@@ -212,19 +219,19 @@
 
   /** Toast a single expiry summary after a load (critical takes precedence over warning). */
   function notifyExpiry(): void {
-    const c = dashboardCounts(certs.certificates, DEFAULT_THRESHOLDS)
+    const c = dashboardCounts(certs.certificates, thresholds)
     if (c.critical > 0) {
       toast.warning(
         i18n.t('notificationCritical', '{count} certificate(s) expiring within {threshold} days or fewer!', {
           count: c.critical,
-          threshold: DEFAULT_THRESHOLDS.critical,
+          threshold: thresholds.critical,
         }),
       )
     } else if (c.warning > 0) {
       toast(
         i18n.t('notificationWarning', '{count} certificate(s) expiring within {threshold} days or fewer', {
           count: c.warning,
-          threshold: DEFAULT_THRESHOLDS.warning,
+          threshold: thresholds.warning,
         }),
       )
     }
@@ -243,7 +250,7 @@
       toast.error(i18n.t('exportEmpty', 'Nothing to export'))
       return
     }
-    downloadExport(sorted, format)
+    downloadExport(sorted, format, thresholds)
     toast.success(i18n.t('exportSuccess', 'Exported {count} certificate(s)', { count: sorted.length }))
   }
 
@@ -615,7 +622,7 @@
               </tr>
             {:else}
               {#each paged as cert (cert.id)}
-                {@const s = certStatus(cert, DEFAULT_THRESHOLDS)}
+                {@const s = certStatus(cert, thresholds)}
                 {@const parts = parseCertID(cert.id)}
                 <!-- Whole-row button: role="button" + aria-label gives SR users a single
                      focusable target named by the common name; Enter activates the detail
@@ -694,8 +701,8 @@
         </div>
       {:else}
         {#each paged as cert (cert.id)}
-          {@const s = certStatus(cert, DEFAULT_THRESHOLDS)}
-          <CertCard {cert} {showVaultMount} statusLabel={statusMeta[s].label} onSelect={selectCert} />
+          {@const s = certStatus(cert, thresholds)}
+          <CertCard {cert} {showVaultMount} statusLabel={statusMeta[s].label} {thresholds} onSelect={selectCert} />
         {/each}
       {/if}
     </div>
@@ -764,6 +771,7 @@
   cert={selected}
   open={certModalOpen}
   onOpenChange={(value) => (certModalOpen = value)}
+  {thresholds}
 />
 
 <CommandPalette

--- a/app/web/frontend/src/lib/api.ts
+++ b/app/web/frontend/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   DetailedCertificate,
   I18nResponse,
   PemResponse,
+  PublicConfigResponse,
   SettingsFile,
   StatusResponse,
   VersionInfo,
@@ -58,6 +59,9 @@ export const api = {
   },
   status(): Promise<StatusResponse> {
     return request<StatusResponse>('/api/status')
+  },
+  config(): Promise<PublicConfigResponse> {
+    return request<PublicConfigResponse>('/api/config')
   },
   version(): Promise<VersionInfo> {
     return request<VersionInfo>('/api/version')

--- a/app/web/frontend/src/lib/components/CertCard.svelte
+++ b/app/web/frontend/src/lib/components/CertCard.svelte
@@ -10,20 +10,21 @@
   } from '$lib/utils/cert-status'
   import { formatDate, formatTime } from '$lib/utils/cert-filter'
   import { certDisplayName } from '$lib/utils/cert-label'
-  import type { Certificate } from '$lib/types'
+  import type { Certificate, ExpirationThresholds } from '$lib/types'
 
   interface Props {
     cert: Certificate
     showVaultMount: boolean
     statusLabel: string
+    thresholds?: ExpirationThresholds
     onSelect: (cert: Certificate) => void
   }
 
-  const { cert, showVaultMount, statusLabel, onSelect }: Props = $props()
+  const { cert, showVaultMount, statusLabel, thresholds = DEFAULT_THRESHOLDS, onSelect }: Props = $props()
 
   const i18n = getI18n()
 
-  const s = $derived(certStatus(cert, DEFAULT_THRESHOLDS))
+  const s = $derived(certStatus(cert, thresholds))
   const parts = $derived(parseCertID(cert.id))
 
   /** Localized expiry label: compact "{n}d" ahead, descriptive when due/past. */

--- a/app/web/frontend/src/lib/components/CertDetailModal.svelte
+++ b/app/web/frontend/src/lib/components/CertDetailModal.svelte
@@ -14,15 +14,16 @@
   import { formatDate, formatTime } from '$lib/utils/cert-filter'
   import { copyToClipboard } from '$lib/utils/clipboard'
   import { getI18n } from '$lib/stores/i18n.svelte'
-  import type { Certificate, CertStatus, DetailedCertificate } from '$lib/types'
+  import type { Certificate, CertStatus, DetailedCertificate, ExpirationThresholds } from '$lib/types'
 
   interface Props {
     cert: Certificate | null
     open: boolean
     onOpenChange: (open: boolean) => void
+    thresholds?: ExpirationThresholds
   }
 
-  const { cert, open, onOpenChange }: Props = $props()
+  const { cert, open, onOpenChange, thresholds = DEFAULT_THRESHOLDS }: Props = $props()
   const i18n = getI18n()
 
   const statusLabels = $derived<Record<CertStatus, string>>({
@@ -146,7 +147,7 @@
     }
   }
 
-  const status = $derived(cert ? certStatus(cert, DEFAULT_THRESHOLDS) : 'valid')
+  const status = $derived(cert ? certStatus(cert, thresholds) : 'valid')
   const days = $derived(cert ? daysUntilExpiry(cert) : 0)
   const expiryTone = $derived(cert ? tone(status) : 'ok')
   const source = $derived(cert ? parseCertID(cert.id) : null)

--- a/app/web/frontend/src/lib/stores/config.svelte.ts
+++ b/app/web/frontend/src/lib/stores/config.svelte.ts
@@ -1,0 +1,43 @@
+import { api, ApiError } from '$lib/api'
+import type { ExpirationThresholds } from '$lib/types'
+import { DEFAULT_THRESHOLDS } from '$lib/utils/cert-status'
+import { thresholdsFromConfig } from '$lib/utils/config-thresholds'
+
+export interface ConfigStore {
+  readonly thresholds: ExpirationThresholds
+  readonly loading: boolean
+  readonly error: string | null
+  refresh(): Promise<void>
+}
+
+export function createConfigStore(): ConfigStore {
+  let thresholds = $state<ExpirationThresholds>({ ...DEFAULT_THRESHOLDS })
+  let loading = $state(false)
+  let error = $state<string | null>(null)
+
+  async function refresh(): Promise<void> {
+    loading = true
+    error = null
+    try {
+      const response = await api.config()
+      thresholds = thresholdsFromConfig(response.expirationThresholds)
+    } catch (err: unknown) {
+      error = err instanceof ApiError ? err.message : 'Failed to fetch config'
+    } finally {
+      loading = false
+    }
+  }
+
+  return {
+    get thresholds() {
+      return thresholds
+    },
+    get loading() {
+      return loading
+    },
+    get error() {
+      return error
+    },
+    refresh,
+  }
+}

--- a/app/web/frontend/src/lib/types.ts
+++ b/app/web/frontend/src/lib/types.ts
@@ -142,3 +142,11 @@ export interface AdminVaultAddedResponse {
   key: string
   vault: VaultInstance
 }
+
+/** Public config from GET /api/config (no secrets). */
+export interface PublicConfigResponse {
+  expirationThresholds: ExpirationThresholds
+  metrics?: { per_certificate?: boolean; enhanced_metrics?: boolean }
+  pkiMounts?: string[]
+  vaults?: { id: string; displayName: string; pkiMounts: string[] }[]
+}

--- a/app/web/frontend/src/lib/utils/config-thresholds.test.ts
+++ b/app/web/frontend/src/lib/utils/config-thresholds.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_THRESHOLDS } from '$lib/utils/cert-status'
+import { thresholdsFromConfig } from '$lib/utils/config-thresholds'
+
+describe('thresholdsFromConfig', () => {
+  it('returns fallback when raw is missing', () => {
+    expect(thresholdsFromConfig(undefined)).toEqual(DEFAULT_THRESHOLDS)
+  })
+
+  it('returns fallback when critical or warning is missing', () => {
+    expect(thresholdsFromConfig({ critical: 14 })).toEqual(DEFAULT_THRESHOLDS)
+    expect(thresholdsFromConfig({ warning: 60 })).toEqual(DEFAULT_THRESHOLDS)
+    expect(thresholdsFromConfig({})).toEqual(DEFAULT_THRESHOLDS)
+  })
+
+  it('returns fallback for zero or negative values', () => {
+    expect(thresholdsFromConfig({ critical: 0, warning: 30 })).toEqual(DEFAULT_THRESHOLDS)
+    expect(thresholdsFromConfig({ critical: 7, warning: 0 })).toEqual(DEFAULT_THRESHOLDS)
+    expect(thresholdsFromConfig({ critical: -1, warning: 30 })).toEqual(DEFAULT_THRESHOLDS)
+  })
+
+  it('returns fallback for non-finite numbers', () => {
+    expect(thresholdsFromConfig({ critical: Number.NaN, warning: 30 })).toEqual(DEFAULT_THRESHOLDS)
+    expect(thresholdsFromConfig({ critical: 7, warning: Number.POSITIVE_INFINITY })).toEqual(
+      DEFAULT_THRESHOLDS,
+    )
+  })
+
+  it('returns custom thresholds when both are positive numbers', () => {
+    expect(thresholdsFromConfig({ critical: 14, warning: 60 })).toEqual({
+      critical: 14,
+      warning: 60,
+    })
+  })
+
+  it('allows warning < critical without inventing product rules', () => {
+    expect(thresholdsFromConfig({ critical: 30, warning: 7 })).toEqual({
+      critical: 30,
+      warning: 7,
+    })
+  })
+
+  it('uses an explicit fallback when provided', () => {
+    const custom = { critical: 1, warning: 2 }
+    expect(thresholdsFromConfig(undefined, custom)).toEqual(custom)
+  })
+})

--- a/app/web/frontend/src/lib/utils/config-thresholds.ts
+++ b/app/web/frontend/src/lib/utils/config-thresholds.ts
@@ -1,0 +1,24 @@
+import type { ExpirationThresholds } from '$lib/types'
+import { DEFAULT_THRESHOLDS } from '$lib/utils/cert-status'
+
+/**
+ * Parse expiration thresholds from a public config payload.
+ * Invalid or missing values fall back to DEFAULT_THRESHOLDS.
+ */
+export function thresholdsFromConfig(
+  raw: { critical?: number; warning?: number } | undefined,
+  fallback: ExpirationThresholds = DEFAULT_THRESHOLDS,
+): ExpirationThresholds {
+  if (
+    raw != null &&
+    typeof raw.critical === 'number' &&
+    typeof raw.warning === 'number' &&
+    Number.isFinite(raw.critical) &&
+    Number.isFinite(raw.warning) &&
+    raw.critical > 0 &&
+    raw.warning > 0
+  ) {
+    return { critical: raw.critical, warning: raw.warning }
+  }
+  return fallback
+}


### PR DESCRIPTION
## Summary
- Fetch public `/api/config` into a new config store and use live critical/warning days for badges, filters, exports, and expiry toasts
- Keep hardcoded 7/30 only as a safe fallback when config is missing or invalid
- Add pure `thresholdsFromConfig` helper with unit tests

#### Test plan
- [x] `cd app/web/frontend && pnpm check`
- [x] `cd app/web/frontend && pnpm test`
- [ ] Optional: change admin thresholds and hard-refresh dashboard status chip copy

Generated with [Devin](https://devin.ai)