### PR TITLE
fix(web): Track A remainder (expiry toast, modal races, sonner, shell extract, admin tests)

### DIFF
--- a/app/web/frontend/package.json
+++ b/app/web/frontend/package.json
@@ -32,7 +32,6 @@
     "@lucide/svelte": "1.24.0",
     "bits-ui": "^2.18.1",
     "clsx": "^2.1.1",
-    "mode-watcher": "^1.1.0",
     "svelte-sonner": "^1.1.1",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/app/web/frontend/pnpm-lock.yaml
+++ b/app/web/frontend/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      mode-watcher:
-        specifier: ^1.1.0
-        version: 1.1.0(svelte@5.56.4)
       svelte-sonner:
         specifier: ^1.1.1
         version: 1.1.1(svelte@5.56.4)
@@ -822,11 +819,6 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  mode-watcher@1.1.0:
-    resolution: {integrity: sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g==}
-    peerDependencies:
-      svelte: ^5.27.0
-
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -887,16 +879,6 @@ packages:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  runed@0.23.4:
-    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
-    peerDependencies:
-      svelte: ^5.7.0
-
-  runed@0.25.0:
-    resolution: {integrity: sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg==}
-    peerDependencies:
-      svelte: ^5.7.0
 
   runed@0.28.0:
     resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
@@ -967,12 +949,6 @@ packages:
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.30.2
-
-  svelte-toolbelt@0.7.1:
-    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
-    engines: {node: '>=18', pnpm: '>=8.7.0'}
-    peerDependencies:
-      svelte: ^5.0.0
 
   svelte@5.56.4:
     resolution: {integrity: sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==}
@@ -1812,12 +1788,6 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mode-watcher@1.1.0(svelte@5.56.4):
-    dependencies:
-      runed: 0.25.0(svelte@5.56.4)
-      svelte: 5.56.4
-      svelte-toolbelt: 0.7.1(svelte@5.56.4)
-
   mri@1.2.0: {}
 
   nanoid@3.3.12: {}
@@ -1881,16 +1851,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.5
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
-
-  runed@0.23.4(svelte@5.56.4):
-    dependencies:
-      esm-env: 1.2.2
-      svelte: 5.56.4
-
-  runed@0.25.0(svelte@5.56.4):
-    dependencies:
-      esm-env: 1.2.2
-      svelte: 5.56.4
 
   runed@0.28.0(svelte@5.56.4):
     dependencies:
@@ -1960,13 +1920,6 @@ snapshots:
       svelte: 5.56.4
     transitivePeerDependencies:
       - '@sveltejs/kit'
-
-  svelte-toolbelt@0.7.1(svelte@5.56.4):
-    dependencies:
-      clsx: 2.1.1
-      runed: 0.23.4(svelte@5.56.4)
-      style-to-object: 1.0.14
-      svelte: 5.56.4
 
   svelte@5.56.4:
     dependencies:

--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -7,7 +7,6 @@
   import Search from '@lucide/svelte/icons/search'
   import Sun from '@lucide/svelte/icons/sun'
   import { Toaster } from '$lib/components/ui/sonner'
-  import { Skeleton } from '$lib/components/ui/skeleton'
   import * as Select from '$lib/components/ui/select'
   import CertDetailModal from '$lib/components/CertDetailModal.svelte'
   import CertTypeSelect from '$lib/components/CertTypeSelect.svelte'
@@ -16,32 +15,25 @@
   import ErrorBanner from '$lib/components/ErrorBanner.svelte'
   import MountSelectorDialog from '$lib/components/MountSelectorDialog.svelte'
   import StatusOverview from '$lib/components/StatusOverview.svelte'
-  import CertCard from '$lib/components/CertCard.svelte'
+  import CertTable from '$lib/components/CertTable.svelte'
+  import CertMobileList from '$lib/components/CertMobileList.svelte'
+  import PaginationBar from '$lib/components/PaginationBar.svelte'
   import CommandPalette from '$lib/components/CommandPalette.svelte'
   import { createCertsStore } from '$lib/stores/certs.svelte'
   import { createConfigStore } from '$lib/stores/config.svelte'
   import { createStatusStore } from '$lib/stores/status.svelte'
   import { createThemeStore } from '$lib/stores/theme.svelte'
   import { createI18nStore, setI18nContext, LANGUAGES } from '$lib/stores/i18n.svelte'
-  import {
-    certStatus,
-    daysUntilExpiry,
-    parseCertID,
-    statusBadgeClass,
-    rowClassForStatus,
-  } from '$lib/utils/cert-status'
+  import { parseCertID } from '$lib/utils/cert-status'
   import {
     matchesFilters,
     sortCerts,
     paginate,
     dashboardCounts,
-    formatDate,
-    formatTime,
     type CertTypeFilter,
     type SortDirection,
     type SortKey,
   } from '$lib/utils/cert-filter'
-  import { certDisplayName } from '$lib/utils/cert-label'
   import { parseUrlState, writeUrlState, type UrlState } from '$lib/utils/url-state'
   import { downloadExport, type ExportFormat } from '$lib/utils/export'
   import { expiryTier, shouldNotifyExpiry, type ExpiryTier } from '$lib/utils/expiry-notify'
@@ -69,15 +61,6 @@
     revoked: { label: i18n.t('statusLabelRevoked', 'Revoked'), desc: i18n.t('statusDescRevoked', 'Revoked by CA') },
   })
   const langName = $derived(LANGUAGES.find((l) => l.code === i18n.lang)?.name ?? i18n.lang.toUpperCase())
-
-  /** Localized expiry label for the table: compact "{n}d" ahead, descriptive when due/past. */
-  function expiryLabel(cert: Certificate): string {
-    const days = daysUntilExpiry(cert)
-    if (days > 0) return i18n.t('daysRemainingShort', '{days}d', { days })
-    if (days === 0) return i18n.t('expiringToday', 'Expires today')
-    const ago = Math.abs(days)
-    return i18n.t(ago === 1 ? 'expiredDaysSingular' : 'expiredDays', 'Expired {days} days ago', { days: ago })
-  }
 
   let search = $state('')
   let statusFilters = $state<CertStatus[]>([])
@@ -589,180 +572,44 @@
       </div>
     </div>
 
-    <div class="vcv-table-wrapper">
-      {#if initialLoad && certs.certificates.length === 0}
-        <div class="vcv-table-skeleton">
-          {#each Array(8) as _, i (i)}
-            <div class="vcv-skeleton-row">
-              <Skeleton class="h-5 flex-1" />
-              <Skeleton class="h-5 w-24" />
-              <Skeleton class="h-5 w-20" />
-            </div>
-          {/each}
-        </div>
-      {:else}
-        <table class="vcv-table">
-          <colgroup>
-            <col class="vcv-col-cert" />
-            <col class="vcv-col-expiry" />
-          </colgroup>
-          <thead>
-            <tr>
-              <th scope="col">{i18n.t('columnCommonName', 'Common Name')}</th>
-              <th scope="col" class="vcv-col-expiry-head">{i18n.t('columnExpiresAt', 'Expires')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#if paged.length === 0}
-              <tr>
-                <td colspan="2" class="vcv-empty-row">
-                  {#if certs.loading}
-                    {i18n.t('labelLoading', 'Loading…')}
-                  {:else if hasActiveFilters}
-                    <div class="vcv-empty-state">
-                      <p class="vcv-empty-title">{i18n.t('tableNoMatch', 'No certificates match the current filters.')}</p>
-                      <button type="button" class="vcv-button vcv-button-small vcv-button-ghost vcv-button-pill" onclick={clearAllFilters}>
-                        {i18n.t('filterChipReset', 'Clear all')}
-                      </button>
-                    </div>
-                  {:else}
-                    <div class="vcv-empty-state">
-                      <p class="vcv-empty-title">{i18n.t('tableEmpty', 'No certificates found.')}</p>
-                      <p class="vcv-empty-hint">{i18n.t('tableEmptyHint', 'No PKI mount returned any certificates yet.')}</p>
-                    </div>
-                  {/if}
-                </td>
-              </tr>
-            {:else}
-              {#each paged as cert (cert.id)}
-                {@const s = certStatus(cert, thresholds)}
-                {@const parts = parseCertID(cert.id)}
-                <!-- Whole-row button: role="button" + aria-label gives SR users a single
-                     focusable target named by the common name; Enter activates the detail
-                     modal. Kept over a nested cell button to preserve one tab stop per row. -->
-                <tr
-                  class="{rowClassForStatus(s)} vcv-row-clickable"
-                  onclick={() => selectCert(cert)}
-                  onkeydown={(event) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault()
-                      selectCert(cert)
-                    }
-                  }}
-                  tabindex="0"
-                  role="button"
-                  aria-label={`${certDisplayName(cert, i18n.t('certUnnamed', 'Unnamed certificate'))}: ${i18n.t('buttonDetails', 'Details')}`}
-                >
-                  <td class="vcv-col-cert">
-                    <div class="vcv-cert-header">
-                      <span class="vcv-cn-name">{cert.commonName || '—'}</span>
-                      <div class="vcv-cert-meta-row">
-                        {#if showVaultMount}
-                          <span class="vcv-cert-meta-item">{parts.vault || '—'}</span>
-                          <span class="vcv-cert-meta-item">{parts.mount || '—'}</span>
-                        {/if}
-                        <span class="vcv-cert-status-inline {statusBadgeClass(s)}">{statusMeta[s].label}</span>
-                      </div>
-                    </div>
-                    {#if cert.sans.length > 0}
-                      <div class="vcv-san-row">
-                        <span class="vcv-san-tag" title={cert.sans.join(', ')}>{cert.sans.join(', ')}</span>
-                      </div>
-                    {/if}
-                  </td>
-                  <td class="vcv-col-expiry">
-                    <div class="vcv-expiry-cell">
-                      <div class="vcv-expiry-main">
-                        <div class="vcv-expiry-count vcv-days-{s}">{expiryLabel(cert)}</div>
-                        <div class="vcv-expiry-datetime">
-                          <span class="vcv-expiry-date">{formatDate(cert.expiresAt)}</span>
-                          <span class="vcv-date-secondary">· {formatTime(cert.expiresAt)} UTC</span>
-                        </div>
-                      </div>
-                      <span class="vcv-row-action" aria-hidden="true">{i18n.t('buttonDetails', 'Details')}</span>
-                    </div>
-                  </td>
-                </tr>
-              {/each}
-            {/if}
-          </tbody>
-        </table>
-      {/if}
-    </div>
+    <CertTable
+      certs={paged}
+      loading={certs.loading}
+      {initialLoad}
+      hasInventory={certs.certificates.length > 0}
+      {hasActiveFilters}
+      {showVaultMount}
+      {statusMeta}
+      {thresholds}
+      onSelect={selectCert}
+      onClearFilters={clearAllFilters}
+    />
 
-    <div class="vcv-certs-mobile-cards">
-      {#if initialLoad && certs.certificates.length === 0}
-        {#each Array(6) as _, i (i)}
-          <div class="vcv-cert-card">
-            <Skeleton class="h-5 w-3/4" />
-            <Skeleton class="h-4 w-1/2" />
-          </div>
-        {/each}
-      {:else if paged.length === 0}
-        <div class="vcv-certs-mobile-empty">
-          {#if certs.loading}
-            {i18n.t('labelLoading', 'Loading…')}
-          {:else if hasActiveFilters}
-            <p class="vcv-empty-title">{i18n.t('tableNoMatch', 'No certificates match the current filters.')}</p>
-            <button type="button" class="vcv-button vcv-button-small vcv-button-ghost vcv-button-pill" onclick={clearAllFilters}>
-              {i18n.t('filterChipReset', 'Clear all')}
-            </button>
-          {:else}
-            <p class="vcv-empty-title">{i18n.t('tableEmpty', 'No certificates found.')}</p>
-            <p class="vcv-empty-hint">{i18n.t('tableEmptyHint', 'No PKI mount returned any certificates yet.')}</p>
-          {/if}
-        </div>
-      {:else}
-        {#each paged as cert (cert.id)}
-          {@const s = certStatus(cert, thresholds)}
-          <CertCard {cert} {showVaultMount} statusLabel={statusMeta[s].label} {thresholds} onSelect={selectCert} />
-        {/each}
-      {/if}
-    </div>
+    <CertMobileList
+      certs={paged}
+      loading={certs.loading}
+      {initialLoad}
+      hasInventory={certs.certificates.length > 0}
+      {hasActiveFilters}
+      {showVaultMount}
+      {statusMeta}
+      {thresholds}
+      onSelect={selectCert}
+      onClearFilters={clearAllFilters}
+    />
 
-    <div class="vcv-pagination-bar">
-      <div class="vcv-page-size">
-        <span id="vcv-page-size-label">{i18n.t('paginationPageSizeLabel', 'Results per page')}</span>
-        <Select.Root
-          type="single"
-          value={String(pageSize)}
-          onValueChange={(value) => {
-            if (!value) return
-            pageSize = value === 'all' ? 'all' : Number(value)
-            pageIndex = 0
-          }}
-        >
-          <Select.Trigger class="vcv-select vcv-page-size-select h-9" aria-labelledby="vcv-page-size-label">
-            {pageSize === 'all' ? i18n.t('paginationPageSizeAll', 'All') : String(pageSize)}
-          </Select.Trigger>
-          <Select.Content>
-            <Select.Item value="25">25</Select.Item>
-            <Select.Item value="50">50</Select.Item>
-            <Select.Item value="100">100</Select.Item>
-            <Select.Item value="all">{i18n.t('paginationPageSizeAll', 'All')}</Select.Item>
-          </Select.Content>
-        </Select.Root>
-      </div>
-      <span class="vcv-page-info">{pageInfoText()}</span>
-      <div class="vcv-page-buttons">
-        <button
-          type="button"
-          class="vcv-button vcv-button-small vcv-button-ghost vcv-button-pill"
-          disabled={safePage === 0}
-          onclick={() => (pageIndex = Math.max(0, safePage - 1))}
-        >
-          {i18n.t('paginationPrev', 'Previous')}
-        </button>
-        <button
-          type="button"
-          class="vcv-button vcv-button-small vcv-button-ghost vcv-button-pill"
-          disabled={safePage >= totalPages - 1}
-          onclick={() => (pageIndex = Math.min(totalPages - 1, safePage + 1))}
-        >
-          {i18n.t('paginationNext', 'Next')}
-        </button>
-      </div>
-    </div>
+    <PaginationBar
+      {pageSize}
+      {safePage}
+      {totalPages}
+      pageInfoText={pageInfoText()}
+      onPageSizeChange={(size) => {
+        pageSize = size
+        pageIndex = 0
+      }}
+      onPrev={() => (pageIndex = Math.max(0, safePage - 1))}
+      onNext={() => (pageIndex = Math.min(totalPages - 1, safePage + 1))}
+    />
   </main>
 
   <footer class="vcv-footer" aria-label={i18n.t('footerLabel', 'Site information')}>

--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -44,6 +44,7 @@
   import { certDisplayName } from '$lib/utils/cert-label'
   import { parseUrlState, writeUrlState, type UrlState } from '$lib/utils/url-state'
   import { downloadExport, type ExportFormat } from '$lib/utils/export'
+  import { expiryTier, shouldNotifyExpiry, type ExpiryTier } from '$lib/utils/expiry-notify'
   import type { Certificate, CertStatus } from '$lib/types'
 
   const i18n = setI18nContext(createI18nStore())
@@ -108,6 +109,8 @@
   // Opt-in certificate auto-refresh interval in seconds; 0 = off (default).
   let autoRefreshSec = $state(0)
   const AUTO_REFRESH_OPTIONS = [0, 30, 60, 300]
+  /** Last expiry tier we toasted, so auto-refresh does not spam identical alerts. */
+  let lastNotifiedTier = $state<ExpiryTier>('none')
 
   const filtered = $derived(
     certs.certificates.filter((cert) =>
@@ -206,28 +209,37 @@
       }
       if (!certs.error) {
         lastUpdated = new Date()
-        notifyExpiry()
+        notifyExpiry(true)
       }
       return
     }
     await Promise.all(promises)
     if (!certs.error) {
       lastUpdated = new Date()
-      notifyExpiry()
+      notifyExpiry(false)
     }
   }
 
-  /** Toast a single expiry summary after a load (critical takes precedence over warning). */
-  function notifyExpiry(): void {
+  /**
+   * Toast a single expiry summary after a load.
+   * Initial load always notifies when tier ≠ none; later loads only when tier increases.
+   */
+  function notifyExpiry(isInitial: boolean): void {
     const c = dashboardCounts(certs.certificates, thresholds)
-    if (c.critical > 0) {
+    const tier = expiryTier(c)
+    if (tier === 'none') {
+      lastNotifiedTier = 'none'
+      return
+    }
+    if (!shouldNotifyExpiry({ isInitial, tier, lastNotifiedTier })) return
+    if (tier === 'critical') {
       toast.warning(
         i18n.t('notificationCritical', '{count} certificate(s) expiring within {threshold} days or fewer!', {
           count: c.critical,
           threshold: thresholds.critical,
         }),
       )
-    } else if (c.warning > 0) {
+    } else {
       toast(
         i18n.t('notificationWarning', '{count} certificate(s) expiring within {threshold} days or fewer', {
           count: c.warning,
@@ -235,6 +247,7 @@
         }),
       )
     }
+    lastNotifiedTier = tier
   }
 
   async function manualRefresh(): Promise<void> {

--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -383,7 +383,7 @@
 
 <svelte:window onkeydown={onSearchKeydown} />
 
-<Toaster richColors position="bottom-right" />
+<Toaster richColors position="bottom-right" theme={theme.theme} />
 
 <a href="#vcv-main-content" class="vcv-skip-link">{i18n.t('skipToContent', 'Skip to main content')}</a>
 

--- a/app/web/frontend/src/lib/components/CertDetailModal.svelte
+++ b/app/web/frontend/src/lib/components/CertDetailModal.svelte
@@ -46,37 +46,52 @@
   let issuerError = $state<string | null>(null)
 
   let copiedField = $state<string | null>(null)
+  let copyTimer: ReturnType<typeof setTimeout> | null = null
+  /** Bumped on each details request so stale responses are ignored. */
+  let detailsReqId = 0
+  /** Bumped on each issuer request so stale responses are ignored. */
+  let issuerReqId = 0
 
   function loadDetails(): void {
     if (!cert) return
+    const reqId = ++detailsReqId
+    const id = cert.id
     loading = true
     error = null
     api
-      .getCertificateDetails(cert.id)
+      .getCertificateDetails(id)
       .then((data) => {
+        if (reqId !== detailsReqId) return
         details = data
       })
       .catch((err: unknown) => {
+        if (reqId !== detailsReqId) return
         error = err instanceof ApiError ? err.message : i18n.t('loadDetailsNetworkError', 'Failed to load details')
       })
       .finally(() => {
+        if (reqId !== detailsReqId) return
         loading = false
       })
   }
 
   function loadIssuer(): void {
     if (!cert) return
+    const reqId = ++issuerReqId
+    const id = cert.id
     issuerLoading = true
     issuerError = null
     api
-      .getCertificateCA(cert.id)
+      .getCertificateCA(id)
       .then((data) => {
+        if (reqId !== issuerReqId) return
         issuer = data
       })
       .catch((err: unknown) => {
+        if (reqId !== issuerReqId) return
         issuerError = err instanceof ApiError ? err.message : i18n.t('loadDetailsNetworkError', 'Failed to load details')
       })
       .finally(() => {
+        if (reqId !== issuerReqId) return
         issuerLoading = false
       })
   }
@@ -84,11 +99,20 @@
   // Reset everything and (re)load whenever the dialog opens for a certificate.
   $effect(() => {
     if (!open || !cert) {
+      detailsReqId++
+      issuerReqId++
       details = null
       issuer = null
       error = null
       issuerError = null
+      loading = false
+      issuerLoading = false
       view = 'certificate'
+      if (copyTimer) {
+        clearTimeout(copyTimer)
+        copyTimer = null
+      }
+      copiedField = null
       return
     }
     // Depend on the selected certificate so switching certs reloads.
@@ -96,7 +120,12 @@
     view = 'certificate'
     issuer = null
     issuerError = null
+    issuerReqId++
     loadDetails()
+    return () => {
+      detailsReqId++
+      issuerReqId++
+    }
   })
 
   function showIssuer(): void {
@@ -114,9 +143,11 @@
       toast.error(i18n.t('copyFailed', 'Copy failed — clipboard unavailable'))
       return
     }
+    if (copyTimer) clearTimeout(copyTimer)
     copiedField = field
-    setTimeout(() => {
+    copyTimer = setTimeout(() => {
       if (copiedField === field) copiedField = null
+      copyTimer = null
     }, 1500)
   }
 

--- a/app/web/frontend/src/lib/components/CertDetailModal.test.ts
+++ b/app/web/frontend/src/lib/components/CertDetailModal.test.ts
@@ -113,4 +113,79 @@ describe('CertDetailModal', () => {
     expect(await screen.findByText('Example Intermediate CA')).toBeInTheDocument()
     expect(getCertificateDetails).toHaveBeenCalledTimes(2)
   })
+
+  it('ignores a stale details response after switching certificates', async () => {
+    const certB: Certificate = {
+      ...cert,
+      id: 'vault1|pki-int:cc:dd',
+      serialNumber: 'cc:dd',
+      commonName: 'other.example.com',
+    }
+    let resolveA: (value: DetailedCertificate) => void = () => {}
+    const deferredA = new Promise<DetailedCertificate>((resolve) => {
+      resolveA = resolve
+    })
+    getCertificateDetails.mockImplementation((id: string) => {
+      if (id === cert.id) return deferredA
+      return Promise.resolve(
+        detailed({
+          id: certB.id,
+          serialNumber: certB.serialNumber,
+          commonName: certB.commonName,
+          issuer: 'Issuer B',
+          subject: 'CN=other.example.com',
+        }),
+      )
+    })
+    const { rerender } = render(CertDetailModal, {
+      props: { cert, open: true, onOpenChange: vi.fn() },
+    })
+    await waitFor(() => expect(getCertificateDetails).toHaveBeenCalledWith(cert.id))
+    await rerender({ cert: certB, open: true, onOpenChange: vi.fn() })
+    expect(await screen.findByText('Issuer B')).toBeInTheDocument()
+    resolveA(
+      detailed({
+        id: cert.id,
+        issuer: 'Stale Issuer A',
+        subject: 'CN=web.example.com',
+      }),
+    )
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByText('Stale Issuer A')).not.toBeInTheDocument()
+    expect(screen.getByText('Issuer B')).toBeInTheDocument()
+  })
+
+  it('ignores a stale details error after a successful newer load', async () => {
+    const certB: Certificate = {
+      ...cert,
+      id: 'vault1|pki-int:ee:ff',
+      serialNumber: 'ee:ff',
+      commonName: 'third.example.com',
+    }
+    let rejectA: (reason?: unknown) => void = () => {}
+    const deferredA = new Promise<DetailedCertificate>((_resolve, reject) => {
+      rejectA = reject
+    })
+    getCertificateDetails.mockImplementation((id: string) => {
+      if (id === cert.id) return deferredA
+      return Promise.resolve(
+        detailed({
+          id: certB.id,
+          serialNumber: certB.serialNumber,
+          commonName: certB.commonName,
+          issuer: 'Issuer Fresh',
+        }),
+      )
+    })
+    const { rerender } = render(CertDetailModal, {
+      props: { cert, open: true, onOpenChange: vi.fn() },
+    })
+    await waitFor(() => expect(getCertificateDetails).toHaveBeenCalledWith(cert.id))
+    await rerender({ cert: certB, open: true, onOpenChange: vi.fn() })
+    expect(await screen.findByText('Issuer Fresh')).toBeInTheDocument()
+    rejectA(new Error('stale failure'))
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument()
+    expect(screen.getByText('Issuer Fresh')).toBeInTheDocument()
+  })
 })

--- a/app/web/frontend/src/lib/components/CertMobileList.svelte
+++ b/app/web/frontend/src/lib/components/CertMobileList.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import { Skeleton } from '$lib/components/ui/skeleton'
+  import CertCard from '$lib/components/CertCard.svelte'
+  import { getI18n } from '$lib/stores/i18n.svelte'
+  import { certStatus } from '$lib/utils/cert-status'
+  import type { Certificate, CertStatus, ExpirationThresholds } from '$lib/types'
+
+  interface Props {
+    certs: Certificate[]
+    loading: boolean
+    initialLoad: boolean
+    hasInventory: boolean
+    hasActiveFilters: boolean
+    showVaultMount: boolean
+    statusMeta: Record<CertStatus, { label: string; desc: string }>
+    thresholds: ExpirationThresholds
+    onSelect: (cert: Certificate) => void
+    onClearFilters: () => void
+  }
+
+  const {
+    certs,
+    loading,
+    initialLoad,
+    hasInventory,
+    hasActiveFilters,
+    showVaultMount,
+    statusMeta,
+    thresholds,
+    onSelect,
+    onClearFilters,
+  }: Props = $props()
+
+  const i18n = getI18n()
+</script>
+
+<div class="vcv-certs-mobile-cards">
+  {#if initialLoad && !hasInventory}
+    {#each Array(6) as _, i (i)}
+      <div class="vcv-cert-card">
+        <Skeleton class="h-5 w-3/4" />
+        <Skeleton class="h-4 w-1/2" />
+      </div>
+    {/each}
+  {:else if certs.length === 0}
+    <div class="vcv-certs-mobile-empty">
+      {#if loading}
+        {i18n.t('labelLoading', 'Loading…')}
+      {:else if hasActiveFilters}
+        <p class="vcv-empty-title">{i18n.t('tableNoMatch', 'No certificates match the current filters.')}</p>
+        <button type="button" class="vcv-button vcv-button-small vcv-button-ghost vcv-button-pill" onclick={onClearFilters}>
+          {i18n.t('filterChipReset', 'Clear all')}
+        </button>
+      {:else}
+        <p class="vcv-empty-title">{i18n.t('tableEmpty', 'No certificates found.')}</p>
+        <p class="vcv-empty-hint">{i18n.t('tableEmptyHint', 'No PKI mount returned any certificates yet.')}</p>
+      {/if}
+    </div>
+  {:else}
+    {#each certs as cert (cert.id)}
+      {@const s = certStatus(cert, thresholds)}
+      <CertCard {cert} {showVaultMount} statusLabel={statusMeta[s].label} {thresholds} onSelect={onSelect} />
+    {/each}
+  {/if}
+</div>

--- a/app/web/frontend/src/lib/components/CertTable.svelte
+++ b/app/web/frontend/src/lib/components/CertTable.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { Skeleton } from '$lib/components/ui/skeleton'
+  import { getI18n } from '$lib/stores/i18n.svelte'
+  import {
+    certStatus,
+    daysUntilExpiry,
+    parseCertID,
+    statusBadgeClass,
+    rowClassForStatus,
+  } from '$lib/utils/cert-status'
+  import { formatDate, formatTime } from '$lib/utils/cert-filter'
+  import { certDisplayName } from '$lib/utils/cert-label'
+  import type { Certificate, CertStatus, ExpirationThresholds } from '$lib/types'
+
+  interface Props {
+    certs: Certificate[]
+    loading: boolean
+    initialLoad: boolean
+    hasInventory: boolean
+    hasActiveFilters: boolean
+    showVaultMount: boolean
+    statusMeta: Record<CertStatus, { label: string; desc: string }>
+    thresholds: ExpirationThresholds
+    onSelect: (cert: Certificate) => void
+    onClearFilters: () => void
+  }
+
+  const {
+    certs,
+    loading,
+    initialLoad,
+    hasInventory,
+    hasActiveFilters,
+    showVaultMount,
+    statusMeta,
+    thresholds,
+    onSelect,
+    onClearFilters,
+  }: Props = $props()
+
+  const i18n = getI18n()
+
+  /** Localized expiry label for the table: compact "{n}d" ahead, descriptive when due/past. */
+  function expiryLabel(cert: Certificate): string {
+    const days = daysUntilExpiry(cert)
+    if (days > 0) return i18n.t('daysRemainingShort', '{days}d', { days })
+    if (days === 0) return i18n.t('expiringToday', 'Expires today')
+    const ago = Math.abs(days)
+    return i18n.t(ago === 1 ? 'expiredDaysSingular' : 'expiredDays', 'Expired {days} days ago', { days: ago })
+  }
+</script>
+
+<div class="vcv-table-wrapper">
+  {#if initialLoad && !hasInventory}
+    <div class="vcv-table-skeleton">
+      {#each Array(8) as _, i (i)}
+        <div class="vcv-skeleton-row">
+          <Skeleton class="h-5 flex-1" />
+          <Skeleton class="h-5 w-24" />
+          <Skeleton class="h-5 w-20" />
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <table class="vcv-table">
+      <colgroup>
+        <col class="vcv-col-cert" />
+        <col class="vcv-col-expiry" />
+      </colgroup>
+      <thead>
+        <tr>
+          <th scope="col">{i18n.t('columnCommonName', 'Common Name')}</th>
+          <th scope="col" class="vcv-col-expiry-head">{i18n.t('columnExpiresAt', 'Expires')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#if certs.length === 0}
+          <tr>
+            <td colspan="2" class="vcv-empty-row">
+              {#if loading}
+                {i18n.t('labelLoading', 'Loading…')}
+              {:else if hasActiveFilters}
+                <div class="vcv-empty-state">
+                  <p class="vcv-empty-title">{i18n.t('tableNoMatch', 'No certificates match the current filters.')}</p>
+                  <button type="button" class="vcv-button vcv-button-small vcv-button-ghost vcv-button-pill" onclick={onClearFilters}>
+                    {i18n.t('filterChipReset', 'Clear all')}
+                  </button>
+                </div>
+              {:else}
+                <div class="vcv-empty-state">
+                  <p class="vcv-empty-title">{i18n.t('tableEmpty', 'No certificates found.')}</p>
+                  <p class="vcv-empty-hint">{i18n.t('tableEmptyHint', 'No PKI mount returned any certificates yet.')}</p>
+                </div>
+              {/if}
+            </td>
+          </tr>
+        {:else}
+          {#each certs as cert (cert.id)}
+            {@const s = certStatus(cert, thresholds)}
+            {@const parts = parseCertID(cert.id)}
+            <!-- Whole-row button: role="button" + aria-label gives SR users a single
+                 focusable target named by the common name; Enter activates the detail
+                 modal. Kept over a nested cell button to preserve one tab stop per row. -->
+            <tr
+              class="{rowClassForStatus(s)} vcv-row-clickable"
+              onclick={() => onSelect(cert)}
+              onkeydown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  onSelect(cert)
+                }
+              }}
+              tabindex="0"
+              role="button"
+              aria-label={`${certDisplayName(cert, i18n.t('certUnnamed', 'Unnamed certificate'))}: ${i18n.t('buttonDetails', 'Details')}`}
+            >
+              <td class="vcv-col-cert">
+                <div class="vcv-cert-header">
+                  <span class="vcv-cn-name">{cert.commonName || '—'}</span>
+                  <div class="vcv-cert-meta-row">
+                    {#if showVaultMount}
+                      <span class="vcv-cert-meta-item">{parts.vault || '—'}</span>
+                      <span class="vcv-cert-meta-item">{parts.mount || '—'}</span>
+                    {/if}
+                    <span class="vcv-cert-status-inline {statusBadgeClass(s)}">{statusMeta[s].label}</span>
+                  </div>
+                </div>
+                {#if cert.sans.length > 0}
+                  <div class="vcv-san-row">
+                    <span class="vcv-san-tag" title={cert.sans.join(', ')}>{cert.sans.join(', ')}</span>
+                  </div>
+                {/if}
+              </td>
+              <td class="vcv-col-expiry">
+                <div class="vcv-expiry-cell">
+                  <div class="vcv-expiry-main">
+                    <div class="vcv-expiry-count vcv-days-{s}">{expiryLabel(cert)}</div>
+                    <div class="vcv-expiry-datetime">
+                      <span class="vcv-expiry-date">{formatDate(cert.expiresAt)}</span>
+                      <span class="vcv-date-secondary">· {formatTime(cert.expiresAt)} UTC</span>
+                    </div>
+                  </div>
+                  <span class="vcv-row-action" aria-hidden="true">{i18n.t('buttonDetails', 'Details')}</span>
+                </div>
+              </td>
+            </tr>
+          {/each}
+        {/if}
+      </tbody>
+    </table>
+  {/if}
+</div>

--- a/app/web/frontend/src/lib/components/CertTable.test.ts
+++ b/app/web/frontend/src/lib/components/CertTable.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/svelte'
+import type { Certificate, ExpirationThresholds } from '$lib/types'
+
+vi.mock('$lib/stores/i18n.svelte', () => ({
+  getI18n: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}))
+
+import CertTable from '$lib/components/CertTable.svelte'
+
+const thresholds: ExpirationThresholds = { critical: 7, warning: 30 }
+
+const cert: Certificate = {
+  id: 'vault1|pki-int:aa:bb',
+  serialNumber: 'aa:bb',
+  commonName: 'web.example.com',
+  sans: ['api.example.com'],
+  certType: 'machine',
+  createdAt: '2024-01-01T00:00:00Z',
+  expiresAt: '2999-01-01T00:00:00Z',
+  revoked: false,
+}
+
+const statusMeta = {
+  valid: { label: 'Valid', desc: 'All good' },
+  warning: { label: 'Warning', desc: '≤ 30 days' },
+  critical: { label: 'Critical', desc: '≤ 7 days' },
+  expired: { label: 'Expired', desc: 'Past expiry' },
+  revoked: { label: 'Revoked', desc: 'Revoked by CA' },
+}
+
+describe('CertTable', () => {
+  it('renders a clickable row with certificate name and details label', () => {
+    render(CertTable, {
+      props: {
+        certs: [cert],
+        loading: false,
+        initialLoad: false,
+        hasInventory: true,
+        hasActiveFilters: false,
+        showVaultMount: false,
+        statusMeta,
+        thresholds,
+        onSelect: vi.fn(),
+        onClearFilters: vi.fn(),
+      },
+    })
+
+    expect(screen.getByRole('button', { name: 'web.example.com: Details' })).toBeInTheDocument()
+    expect(screen.getByText('web.example.com')).toBeInTheDocument()
+    expect(screen.getByText('api.example.com')).toBeInTheDocument()
+  })
+})

--- a/app/web/frontend/src/lib/components/PaginationBar.svelte
+++ b/app/web/frontend/src/lib/components/PaginationBar.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import * as Select from '$lib/components/ui/select'
+  import { getI18n } from '$lib/stores/i18n.svelte'
+
+  interface Props {
+    pageSize: number | 'all'
+    safePage: number
+    totalPages: number
+    pageInfoText: string
+    onPageSizeChange: (size: number | 'all') => void
+    onPrev: () => void
+    onNext: () => void
+  }
+
+  const { pageSize, safePage, totalPages, pageInfoText, onPageSizeChange, onPrev, onNext }: Props = $props()
+
+  const i18n = getI18n()
+</script>
+
+<div class="vcv-pagination-bar">
+  <div class="vcv-page-size">
+    <span id="vcv-page-size-label">{i18n.t('paginationPageSizeLabel', 'Results per page')}</span>
+    <Select.Root
+      type="single"
+      value={String(pageSize)}
+      onValueChange={(value) => {
+        if (!value) return
+        onPageSizeChange(value === 'all' ? 'all' : Number(value))
+      }}
+    >
+      <Select.Trigger class="vcv-select vcv-page-size-select h-9" aria-labelledby="vcv-page-size-label">
+        {pageSize === 'all' ? i18n.t('paginationPageSizeAll', 'All') : String(pageSize)}
+      </Select.Trigger>
+      <Select.Content>
+        <Select.Item value="25">25</Select.Item>
+        <Select.Item value="50">50</Select.Item>
+        <Select.Item value="100">100</Select.Item>
+        <Select.Item value="all">{i18n.t('paginationPageSizeAll', 'All')}</Select.Item>
+      </Select.Content>
+    </Select.Root>
+  </div>
+  <span class="vcv-page-info">{pageInfoText}</span>
+  <div class="vcv-page-buttons">
+    <button
+      type="button"
+      class="vcv-button vcv-button-small vcv-button-ghost vcv-button-pill"
+      disabled={safePage === 0}
+      onclick={onPrev}
+    >
+      {i18n.t('paginationPrev', 'Previous')}
+    </button>
+    <button
+      type="button"
+      class="vcv-button vcv-button-small vcv-button-ghost vcv-button-pill"
+      disabled={safePage >= totalPages - 1}
+      onclick={onNext}
+    >
+      {i18n.t('paginationNext', 'Next')}
+    </button>
+  </div>
+</div>

--- a/app/web/frontend/src/lib/components/ui/sonner/sonner.svelte
+++ b/app/web/frontend/src/lib/components/ui/sonner/sonner.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
 	import { Toaster as Sonner, type ToasterProps as SonnerProps } from "svelte-sonner";
-	import { mode } from "mode-watcher";
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
 	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
 	import OctagonXIcon from '@lucide/svelte/icons/octagon-x';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 
-	let { ...restProps }: SonnerProps = $props();
+	let { theme = "light", ...restProps }: SonnerProps = $props();
 </script>
 
 <Sonner
-	theme={mode.current}
+	{theme}
 	class="toaster group"
 	style="--normal-bg: var(--color-popover); --normal-text: var(--color-popover-foreground); --normal-border: var(--color-border);"
 	{...restProps}

--- a/app/web/frontend/src/lib/stores/admin.svelte.ts
+++ b/app/web/frontend/src/lib/stores/admin.svelte.ts
@@ -1,6 +1,17 @@
 import { api, ApiError } from '$lib/api'
 import type { I18nStore } from '$lib/stores/i18n.svelte'
-import type { AdminVaultStatus, SettingsFile } from '$lib/types'
+import type { AdminVaultStatus, SettingsFile, VaultInstance } from '$lib/types'
+
+/**
+ * Prepare vaults for PUT /api/admin/settings.
+ * Blank tokens so the backend keeps existing secrets (mergeVaultTokens).
+ */
+export function mapVaultsForPut(vaults: VaultInstance[]): VaultInstance[] {
+  return vaults.map((v) => ({
+    ...v,
+    token: v.token && v.token.trim() !== '' ? v.token : '',
+  }))
+}
 
 export interface AdminStore {
   readonly authenticated: boolean
@@ -91,10 +102,7 @@ export function createAdminStore(i18n: I18nStore): AdminStore {
       // token the admin actually typed into the field.
       const toSend: SettingsFile = {
         ...next,
-        vaults: next.vaults.map((v) => ({
-          ...v,
-          token: v.token && v.token.trim() !== '' ? v.token : '',
-        })),
+        vaults: mapVaultsForPut(next.vaults),
       }
       const response = await api.adminPutSettings(toSend)
       settings = {

--- a/app/web/frontend/src/lib/stores/admin.test.ts
+++ b/app/web/frontend/src/lib/stores/admin.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SettingsFile, VaultInstance } from '$lib/types'
+
+const {
+  adminSession,
+  adminLogin,
+  adminLogout,
+  adminGetSettings,
+  adminPutSettings,
+  adminAddVault,
+  adminDeleteVault,
+  adminInvalidateCache,
+  ApiError,
+} = vi.hoisted(() => {
+  class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+      this.name = 'ApiError'
+    }
+  }
+  return {
+    adminSession: vi.fn(),
+    adminLogin: vi.fn(),
+    adminLogout: vi.fn(),
+    adminGetSettings: vi.fn(),
+    adminPutSettings: vi.fn(),
+    adminAddVault: vi.fn(),
+    adminDeleteVault: vi.fn(),
+    adminInvalidateCache: vi.fn(),
+    ApiError,
+  }
+})
+
+vi.mock('$lib/api', () => ({
+  api: {
+    adminSession,
+    adminLogin,
+    adminLogout,
+    adminGetSettings,
+    adminPutSettings,
+    adminAddVault,
+    adminDeleteVault,
+    adminInvalidateCache,
+  },
+  ApiError,
+}))
+
+import { createAdminStore, mapVaultsForPut } from '$lib/stores/admin.svelte'
+import type { I18nStore } from '$lib/stores/i18n.svelte'
+
+const i18n = {
+  t: (_key: string, fallback?: string) => fallback ?? _key,
+} as unknown as I18nStore
+
+function sampleSettings(vaults: VaultInstance[]): SettingsFile {
+  return {
+    app: { env: 'dev', port: 52000 },
+    certificates: { expiration_thresholds: { critical: 7, warning: 30 } },
+    metrics: {},
+    cors: {},
+    vaults,
+  }
+}
+
+function sampleVault(overrides: Partial<VaultInstance> = {}): VaultInstance {
+  return {
+    id: 'vault1',
+    address: 'https://vault.example',
+    pki_mounts: ['pki'],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  adminSession.mockReset()
+  adminLogin.mockReset()
+  adminLogout.mockReset()
+  adminGetSettings.mockReset()
+  adminPutSettings.mockReset()
+  adminAddVault.mockReset()
+  adminDeleteVault.mockReset()
+  adminInvalidateCache.mockReset()
+})
+
+describe('mapVaultsForPut', () => {
+  it('blanks undefined, empty, and whitespace-only tokens', () => {
+    const vaults = [
+      sampleVault({ token: undefined }),
+      sampleVault({ id: 'v2', token: '' }),
+      sampleVault({ id: 'v3', token: '   ' }),
+    ]
+    expect(mapVaultsForPut(vaults).map((v) => v.token)).toEqual(['', '', ''])
+  })
+
+  it('forwards a non-empty typed token', () => {
+    const vaults = [sampleVault({ token: 'test-token-value' })]
+    expect(mapVaultsForPut(vaults)[0]?.token).toBe('test-token-value')
+  })
+})
+
+describe('createAdminStore', () => {
+  it('checkSession sets authenticated from API true/false', async () => {
+    const store = createAdminStore(i18n)
+    adminSession.mockResolvedValueOnce({ authenticated: true })
+    await store.checkSession()
+    expect(store.authenticated).toBe(true)
+    adminSession.mockResolvedValueOnce({ authenticated: false })
+    await store.checkSession()
+    expect(store.authenticated).toBe(false)
+  })
+
+  it('checkSession treats errors as unauthenticated', async () => {
+    const store = createAdminStore(i18n)
+    adminSession.mockRejectedValueOnce(new Error('network'))
+    await store.checkSession()
+    expect(store.authenticated).toBe(false)
+  })
+
+  it('login success authenticates; failure clears auth and sets error', async () => {
+    const store = createAdminStore(i18n)
+    adminLogin.mockResolvedValueOnce({ authenticated: true })
+    expect(await store.login('admin', 'secret')).toBe(true)
+    expect(store.authenticated).toBe(true)
+    adminLogin.mockRejectedValueOnce(new ApiError(401, 'bad credentials'))
+    expect(await store.login('admin', 'wrong')).toBe(false)
+    expect(store.authenticated).toBe(false)
+    expect(store.error).toBe('bad credentials')
+  })
+
+  it('loadSettings stamps original_id on vaults', async () => {
+    const store = createAdminStore(i18n)
+    adminGetSettings.mockResolvedValueOnce({
+      settings: sampleSettings([sampleVault({ id: 'primary' })]),
+      vault_statuses: [{ id: 'primary', enabled: true, connected: true }],
+    })
+    await store.loadSettings()
+    expect(store.settings?.vaults[0]).toMatchObject({ id: 'primary', original_id: 'primary' })
+    expect(store.vaultStatuses).toEqual([{ id: 'primary', enabled: true, connected: true }])
+  })
+
+  it('saveSettings blanks empty tokens and forwards typed tokens', async () => {
+    const store = createAdminStore(i18n)
+    const next = sampleSettings([
+      sampleVault({ id: 'a', token: undefined }),
+      sampleVault({ id: 'b', token: '   ' }),
+      sampleVault({ id: 'c', token: 'test-token-value' }),
+    ])
+    adminPutSettings.mockResolvedValueOnce({
+      settings: sampleSettings([sampleVault({ id: 'a' }), sampleVault({ id: 'b' }), sampleVault({ id: 'c' })]),
+      vault_statuses: [],
+    })
+    expect(await store.saveSettings(next)).toBe(true)
+    expect(adminPutSettings).toHaveBeenCalledTimes(1)
+    const sent = adminPutSettings.mock.calls[0]?.[0] as SettingsFile
+    expect(sent.vaults.map((v) => v.token)).toEqual(['', '', 'test-token-value'])
+    expect(store.successMessage).toBe('Settings saved')
+  })
+
+  it('logout clears authenticated state and settings', async () => {
+    const store = createAdminStore(i18n)
+    adminLogin.mockResolvedValueOnce({ authenticated: true })
+    await store.login('admin', 'secret')
+    adminGetSettings.mockResolvedValueOnce({
+      settings: sampleSettings([sampleVault()]),
+      vault_statuses: [],
+    })
+    await store.loadSettings()
+    adminLogout.mockResolvedValueOnce(undefined)
+    await store.logout()
+    expect(store.authenticated).toBe(false)
+    expect(store.settings).toBeNull()
+    expect(store.vaultStatuses).toEqual([])
+  })
+
+  it('invalidateCache sets successMessage on success', async () => {
+    const store = createAdminStore(i18n)
+    adminInvalidateCache.mockResolvedValueOnce(undefined)
+    await store.invalidateCache()
+    expect(store.successMessage).toBe('Cache invalidated')
+    expect(store.error).toBeNull()
+  })
+})

--- a/app/web/frontend/src/lib/utils/expiry-notify.test.ts
+++ b/app/web/frontend/src/lib/utils/expiry-notify.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { expiryTier, shouldNotifyExpiry, type ExpiryTier } from '$lib/utils/expiry-notify'
+
+describe('expiryTier', () => {
+  it('prefers critical over warning', () => {
+    expect(expiryTier({ critical: 1, warning: 5 })).toBe('critical')
+  })
+
+  it('returns warning when only warning counts', () => {
+    expect(expiryTier({ critical: 0, warning: 2 })).toBe('warning')
+  })
+
+  it('returns none when both zero', () => {
+    expect(expiryTier({ critical: 0, warning: 0 })).toBe('none')
+  })
+})
+
+describe('shouldNotifyExpiry', () => {
+  const cases: {
+    isInitial: boolean
+    tier: ExpiryTier
+    last: ExpiryTier
+    expect: boolean
+  }[] = [
+    { isInitial: true, tier: 'warning', last: 'none', expect: true },
+    { isInitial: true, tier: 'critical', last: 'none', expect: true },
+    { isInitial: true, tier: 'none', last: 'none', expect: false },
+    { isInitial: false, tier: 'warning', last: 'warning', expect: false },
+    { isInitial: false, tier: 'critical', last: 'warning', expect: true },
+    { isInitial: false, tier: 'warning', last: 'critical', expect: false },
+    { isInitial: false, tier: 'none', last: 'warning', expect: false },
+    { isInitial: false, tier: 'critical', last: 'critical', expect: false },
+    { isInitial: false, tier: 'warning', last: 'none', expect: true },
+  ]
+
+  for (const row of cases) {
+    it(`isInitial=${row.isInitial} tier=${row.tier} last=${row.last} → ${row.expect}`, () => {
+      expect(
+        shouldNotifyExpiry({
+          isInitial: row.isInitial,
+          tier: row.tier,
+          lastNotifiedTier: row.last,
+        }),
+      ).toBe(row.expect)
+    })
+  }
+})

--- a/app/web/frontend/src/lib/utils/expiry-notify.ts
+++ b/app/web/frontend/src/lib/utils/expiry-notify.ts
@@ -1,0 +1,28 @@
+export type ExpiryTier = 'none' | 'warning' | 'critical'
+
+const TIER_RANK: Record<ExpiryTier, number> = {
+  none: 0,
+  warning: 1,
+  critical: 2,
+}
+
+/** Derive the toast tier from dashboard expiry counts (critical beats warning). */
+export function expiryTier(counts: { critical: number; warning: number }): ExpiryTier {
+  if (counts.critical > 0) return 'critical'
+  if (counts.warning > 0) return 'warning'
+  return 'none'
+}
+
+/**
+ * Whether to show an expiry toast: always on initial load when tier ≠ none,
+ * and on later loads only when the tier increases (warning → critical).
+ */
+export function shouldNotifyExpiry(args: {
+  isInitial: boolean
+  tier: ExpiryTier
+  lastNotifiedTier: ExpiryTier
+}): boolean {
+  if (args.tier === 'none') return false
+  if (args.isInitial) return true
+  return TIER_RANK[args.tier] > TIER_RANK[args.lastNotifiedTier]
+}


### PR DESCRIPTION
## Summary

#48 (config thresholds) already landed on `main`. Stacked PRs #50–#53 were merged into this branch instead of `main`, which left #49 conflicting.

**This PR** rebases the remaining Track A work onto current `main` and includes:

1. **002** — Gate expiry toasts (initial load or severity increase only)
2. **003** — Ignore stale cert detail/issuer responses (request generation)
3. **004** — Drive Sonner from `createThemeStore`; drop unused `mode-watcher`
4. **005** — Extract `CertTable`, `CertMobileList`, `PaginationBar` from `App.svelte`
5. **006** — Admin store unit tests + `mapVaultsForPut` token blanking

#### Test plan
- [x] Rebased cleanly onto `main` (no conflicts)
- [x] `cd app/web/frontend && pnpm check` / `pnpm test` (pre-rebase verification)
- [ ] CI on this PR

Generated with [Devin](https://devin.ai)