### PR TITLE
fix(web): ignore stale certificate detail responses

### DIFF
--- a/app/web/frontend/src/lib/components/CertDetailModal.svelte
+++ b/app/web/frontend/src/lib/components/CertDetailModal.svelte
@@ -46,37 +46,52 @@
   let issuerError = $state<string | null>(null)
 
   let copiedField = $state<string | null>(null)
+  let copyTimer: ReturnType<typeof setTimeout> | null = null
+  /** Bumped on each details request so stale responses are ignored. */
+  let detailsReqId = 0
+  /** Bumped on each issuer request so stale responses are ignored. */
+  let issuerReqId = 0
 
   function loadDetails(): void {
     if (!cert) return
+    const reqId = ++detailsReqId
+    const id = cert.id
     loading = true
     error = null
     api
-      .getCertificateDetails(cert.id)
+      .getCertificateDetails(id)
       .then((data) => {
+        if (reqId !== detailsReqId) return
         details = data
       })
       .catch((err: unknown) => {
+        if (reqId !== detailsReqId) return
         error = err instanceof ApiError ? err.message : i18n.t('loadDetailsNetworkError', 'Failed to load details')
       })
       .finally(() => {
+        if (reqId !== detailsReqId) return
         loading = false
       })
   }
 
   function loadIssuer(): void {
     if (!cert) return
+    const reqId = ++issuerReqId
+    const id = cert.id
     issuerLoading = true
     issuerError = null
     api
-      .getCertificateCA(cert.id)
+      .getCertificateCA(id)
       .then((data) => {
+        if (reqId !== issuerReqId) return
         issuer = data
       })
       .catch((err: unknown) => {
+        if (reqId !== issuerReqId) return
         issuerError = err instanceof ApiError ? err.message : i18n.t('loadDetailsNetworkError', 'Failed to load details')
       })
       .finally(() => {
+        if (reqId !== issuerReqId) return
         issuerLoading = false
       })
   }
@@ -84,11 +99,20 @@
   // Reset everything and (re)load whenever the dialog opens for a certificate.
   $effect(() => {
     if (!open || !cert) {
+      detailsReqId++
+      issuerReqId++
       details = null
       issuer = null
       error = null
       issuerError = null
+      loading = false
+      issuerLoading = false
       view = 'certificate'
+      if (copyTimer) {
+        clearTimeout(copyTimer)
+        copyTimer = null
+      }
+      copiedField = null
       return
     }
     // Depend on the selected certificate so switching certs reloads.
@@ -96,7 +120,12 @@
     view = 'certificate'
     issuer = null
     issuerError = null
+    issuerReqId++
     loadDetails()
+    return () => {
+      detailsReqId++
+      issuerReqId++
+    }
   })
 
   function showIssuer(): void {
@@ -114,9 +143,11 @@
       toast.error(i18n.t('copyFailed', 'Copy failed — clipboard unavailable'))
       return
     }
+    if (copyTimer) clearTimeout(copyTimer)
     copiedField = field
-    setTimeout(() => {
+    copyTimer = setTimeout(() => {
       if (copiedField === field) copiedField = null
+      copyTimer = null
     }, 1500)
   }
 

--- a/app/web/frontend/src/lib/components/CertDetailModal.test.ts
+++ b/app/web/frontend/src/lib/components/CertDetailModal.test.ts
@@ -113,4 +113,79 @@ describe('CertDetailModal', () => {
     expect(await screen.findByText('Example Intermediate CA')).toBeInTheDocument()
     expect(getCertificateDetails).toHaveBeenCalledTimes(2)
   })
+
+  it('ignores a stale details response after switching certificates', async () => {
+    const certB: Certificate = {
+      ...cert,
+      id: 'vault1|pki-int:cc:dd',
+      serialNumber: 'cc:dd',
+      commonName: 'other.example.com',
+    }
+    let resolveA: (value: DetailedCertificate) => void = () => {}
+    const deferredA = new Promise<DetailedCertificate>((resolve) => {
+      resolveA = resolve
+    })
+    getCertificateDetails.mockImplementation((id: string) => {
+      if (id === cert.id) return deferredA
+      return Promise.resolve(
+        detailed({
+          id: certB.id,
+          serialNumber: certB.serialNumber,
+          commonName: certB.commonName,
+          issuer: 'Issuer B',
+          subject: 'CN=other.example.com',
+        }),
+      )
+    })
+    const { rerender } = render(CertDetailModal, {
+      props: { cert, open: true, onOpenChange: vi.fn() },
+    })
+    await waitFor(() => expect(getCertificateDetails).toHaveBeenCalledWith(cert.id))
+    await rerender({ cert: certB, open: true, onOpenChange: vi.fn() })
+    expect(await screen.findByText('Issuer B')).toBeInTheDocument()
+    resolveA(
+      detailed({
+        id: cert.id,
+        issuer: 'Stale Issuer A',
+        subject: 'CN=web.example.com',
+      }),
+    )
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByText('Stale Issuer A')).not.toBeInTheDocument()
+    expect(screen.getByText('Issuer B')).toBeInTheDocument()
+  })
+
+  it('ignores a stale details error after a successful newer load', async () => {
+    const certB: Certificate = {
+      ...cert,
+      id: 'vault1|pki-int:ee:ff',
+      serialNumber: 'ee:ff',
+      commonName: 'third.example.com',
+    }
+    let rejectA: (reason?: unknown) => void = () => {}
+    const deferredA = new Promise<DetailedCertificate>((_resolve, reject) => {
+      rejectA = reject
+    })
+    getCertificateDetails.mockImplementation((id: string) => {
+      if (id === cert.id) return deferredA
+      return Promise.resolve(
+        detailed({
+          id: certB.id,
+          serialNumber: certB.serialNumber,
+          commonName: certB.commonName,
+          issuer: 'Issuer Fresh',
+        }),
+      )
+    })
+    const { rerender } = render(CertDetailModal, {
+      props: { cert, open: true, onOpenChange: vi.fn() },
+    })
+    await waitFor(() => expect(getCertificateDetails).toHaveBeenCalledWith(cert.id))
+    await rerender({ cert: certB, open: true, onOpenChange: vi.fn() })
+    expect(await screen.findByText('Issuer Fresh')).toBeInTheDocument()
+    rejectA(new Error('stale failure'))
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument()
+    expect(screen.getByText('Issuer Fresh')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- Request generation tokens on cert details and issuer loads so rapid switches cannot paint stale data or errors
- Clear copy timers on dialog close
- Add race-coverage tests for success and error paths

#### Test plan
- [x] `cd app/web/frontend && pnpm check`
- [x] `cd app/web/frontend && pnpm test src/lib/components/CertDetailModal.test.ts`
- [x] full `pnpm test`

Generated with [Devin](https://devin.ai)