### PR TITLE
fix(web): drive Sonner theme from createThemeStore

### DIFF
--- a/app/web/frontend/package.json
+++ b/app/web/frontend/package.json
@@ -32,7 +32,6 @@
     "@lucide/svelte": "1.24.0",
     "bits-ui": "^2.18.1",
     "clsx": "^2.1.1",
-    "mode-watcher": "^1.1.0",
     "svelte-sonner": "^1.1.1",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",

--- a/app/web/frontend/pnpm-lock.yaml
+++ b/app/web/frontend/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      mode-watcher:
-        specifier: ^1.1.0
-        version: 1.1.0(svelte@5.56.4)
       svelte-sonner:
         specifier: ^1.1.1
         version: 1.1.1(svelte@5.56.4)
@@ -822,11 +819,6 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  mode-watcher@1.1.0:
-    resolution: {integrity: sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g==}
-    peerDependencies:
-      svelte: ^5.27.0
-
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -887,16 +879,6 @@ packages:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  runed@0.23.4:
-    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
-    peerDependencies:
-      svelte: ^5.7.0
-
-  runed@0.25.0:
-    resolution: {integrity: sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg==}
-    peerDependencies:
-      svelte: ^5.7.0
 
   runed@0.28.0:
     resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
@@ -967,12 +949,6 @@ packages:
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.30.2
-
-  svelte-toolbelt@0.7.1:
-    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
-    engines: {node: '>=18', pnpm: '>=8.7.0'}
-    peerDependencies:
-      svelte: ^5.0.0
 
   svelte@5.56.4:
     resolution: {integrity: sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==}
@@ -1812,12 +1788,6 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mode-watcher@1.1.0(svelte@5.56.4):
-    dependencies:
-      runed: 0.25.0(svelte@5.56.4)
-      svelte: 5.56.4
-      svelte-toolbelt: 0.7.1(svelte@5.56.4)
-
   mri@1.2.0: {}
 
   nanoid@3.3.12: {}
@@ -1881,16 +1851,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.5
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
-
-  runed@0.23.4(svelte@5.56.4):
-    dependencies:
-      esm-env: 1.2.2
-      svelte: 5.56.4
-
-  runed@0.25.0(svelte@5.56.4):
-    dependencies:
-      esm-env: 1.2.2
-      svelte: 5.56.4
 
   runed@0.28.0(svelte@5.56.4):
     dependencies:
@@ -1960,13 +1920,6 @@ snapshots:
       svelte: 5.56.4
     transitivePeerDependencies:
       - '@sveltejs/kit'
-
-  svelte-toolbelt@0.7.1(svelte@5.56.4):
-    dependencies:
-      clsx: 2.1.1
-      runed: 0.23.4(svelte@5.56.4)
-      style-to-object: 1.0.14
-      svelte: 5.56.4
 
   svelte@5.56.4:
     dependencies:

--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -383,7 +383,7 @@
 
 <svelte:window onkeydown={onSearchKeydown} />
 
-<Toaster richColors position="bottom-right" />
+<Toaster richColors position="bottom-right" theme={theme.theme} />
 
 <a href="#vcv-main-content" class="vcv-skip-link">{i18n.t('skipToContent', 'Skip to main content')}</a>
 

--- a/app/web/frontend/src/lib/components/CertDetailModal.svelte
+++ b/app/web/frontend/src/lib/components/CertDetailModal.svelte
@@ -46,37 +46,52 @@
   let issuerError = $state<string | null>(null)
 
   let copiedField = $state<string | null>(null)
+  let copyTimer: ReturnType<typeof setTimeout> | null = null
+  /** Bumped on each details request so stale responses are ignored. */
+  let detailsReqId = 0
+  /** Bumped on each issuer request so stale responses are ignored. */
+  let issuerReqId = 0
 
   function loadDetails(): void {
     if (!cert) return
+    const reqId = ++detailsReqId
+    const id = cert.id
     loading = true
     error = null
     api
-      .getCertificateDetails(cert.id)
+      .getCertificateDetails(id)
       .then((data) => {
+        if (reqId !== detailsReqId) return
         details = data
       })
       .catch((err: unknown) => {
+        if (reqId !== detailsReqId) return
         error = err instanceof ApiError ? err.message : i18n.t('loadDetailsNetworkError', 'Failed to load details')
       })
       .finally(() => {
+        if (reqId !== detailsReqId) return
         loading = false
       })
   }
 
   function loadIssuer(): void {
     if (!cert) return
+    const reqId = ++issuerReqId
+    const id = cert.id
     issuerLoading = true
     issuerError = null
     api
-      .getCertificateCA(cert.id)
+      .getCertificateCA(id)
       .then((data) => {
+        if (reqId !== issuerReqId) return
         issuer = data
       })
       .catch((err: unknown) => {
+        if (reqId !== issuerReqId) return
         issuerError = err instanceof ApiError ? err.message : i18n.t('loadDetailsNetworkError', 'Failed to load details')
       })
       .finally(() => {
+        if (reqId !== issuerReqId) return
         issuerLoading = false
       })
   }
@@ -84,11 +99,20 @@
   // Reset everything and (re)load whenever the dialog opens for a certificate.
   $effect(() => {
     if (!open || !cert) {
+      detailsReqId++
+      issuerReqId++
       details = null
       issuer = null
       error = null
       issuerError = null
+      loading = false
+      issuerLoading = false
       view = 'certificate'
+      if (copyTimer) {
+        clearTimeout(copyTimer)
+        copyTimer = null
+      }
+      copiedField = null
       return
     }
     // Depend on the selected certificate so switching certs reloads.
@@ -96,7 +120,12 @@
     view = 'certificate'
     issuer = null
     issuerError = null
+    issuerReqId++
     loadDetails()
+    return () => {
+      detailsReqId++
+      issuerReqId++
+    }
   })
 
   function showIssuer(): void {
@@ -114,9 +143,11 @@
       toast.error(i18n.t('copyFailed', 'Copy failed — clipboard unavailable'))
       return
     }
+    if (copyTimer) clearTimeout(copyTimer)
     copiedField = field
-    setTimeout(() => {
+    copyTimer = setTimeout(() => {
       if (copiedField === field) copiedField = null
+      copyTimer = null
     }, 1500)
   }
 

--- a/app/web/frontend/src/lib/components/CertDetailModal.test.ts
+++ b/app/web/frontend/src/lib/components/CertDetailModal.test.ts
@@ -113,4 +113,79 @@ describe('CertDetailModal', () => {
     expect(await screen.findByText('Example Intermediate CA')).toBeInTheDocument()
     expect(getCertificateDetails).toHaveBeenCalledTimes(2)
   })
+
+  it('ignores a stale details response after switching certificates', async () => {
+    const certB: Certificate = {
+      ...cert,
+      id: 'vault1|pki-int:cc:dd',
+      serialNumber: 'cc:dd',
+      commonName: 'other.example.com',
+    }
+    let resolveA: (value: DetailedCertificate) => void = () => {}
+    const deferredA = new Promise<DetailedCertificate>((resolve) => {
+      resolveA = resolve
+    })
+    getCertificateDetails.mockImplementation((id: string) => {
+      if (id === cert.id) return deferredA
+      return Promise.resolve(
+        detailed({
+          id: certB.id,
+          serialNumber: certB.serialNumber,
+          commonName: certB.commonName,
+          issuer: 'Issuer B',
+          subject: 'CN=other.example.com',
+        }),
+      )
+    })
+    const { rerender } = render(CertDetailModal, {
+      props: { cert, open: true, onOpenChange: vi.fn() },
+    })
+    await waitFor(() => expect(getCertificateDetails).toHaveBeenCalledWith(cert.id))
+    await rerender({ cert: certB, open: true, onOpenChange: vi.fn() })
+    expect(await screen.findByText('Issuer B')).toBeInTheDocument()
+    resolveA(
+      detailed({
+        id: cert.id,
+        issuer: 'Stale Issuer A',
+        subject: 'CN=web.example.com',
+      }),
+    )
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByText('Stale Issuer A')).not.toBeInTheDocument()
+    expect(screen.getByText('Issuer B')).toBeInTheDocument()
+  })
+
+  it('ignores a stale details error after a successful newer load', async () => {
+    const certB: Certificate = {
+      ...cert,
+      id: 'vault1|pki-int:ee:ff',
+      serialNumber: 'ee:ff',
+      commonName: 'third.example.com',
+    }
+    let rejectA: (reason?: unknown) => void = () => {}
+    const deferredA = new Promise<DetailedCertificate>((_resolve, reject) => {
+      rejectA = reject
+    })
+    getCertificateDetails.mockImplementation((id: string) => {
+      if (id === cert.id) return deferredA
+      return Promise.resolve(
+        detailed({
+          id: certB.id,
+          serialNumber: certB.serialNumber,
+          commonName: certB.commonName,
+          issuer: 'Issuer Fresh',
+        }),
+      )
+    })
+    const { rerender } = render(CertDetailModal, {
+      props: { cert, open: true, onOpenChange: vi.fn() },
+    })
+    await waitFor(() => expect(getCertificateDetails).toHaveBeenCalledWith(cert.id))
+    await rerender({ cert: certB, open: true, onOpenChange: vi.fn() })
+    expect(await screen.findByText('Issuer Fresh')).toBeInTheDocument()
+    rejectA(new Error('stale failure'))
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument()
+    expect(screen.getByText('Issuer Fresh')).toBeInTheDocument()
+  })
 })

--- a/app/web/frontend/src/lib/components/ui/sonner/sonner.svelte
+++ b/app/web/frontend/src/lib/components/ui/sonner/sonner.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
 	import { Toaster as Sonner, type ToasterProps as SonnerProps } from "svelte-sonner";
-	import { mode } from "mode-watcher";
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
 	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
 	import OctagonXIcon from '@lucide/svelte/icons/octagon-x';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 
-	let { ...restProps }: SonnerProps = $props();
+	let { theme = "light", ...restProps }: SonnerProps = $props();
 </script>
 
 <Sonner
-	theme={mode.current}
+	{theme}
 	class="toaster group"
 	style="--normal-bg: var(--color-popover); --normal-text: var(--color-popover-foreground); --normal-border: var(--color-border);"
 	{...restProps}


### PR DESCRIPTION
## Summary
- Pass `theme={theme.theme}` into the shared Toaster so toasts follow the dashboard light/dark toggle
- Remove unused `mode-watcher` (ModeWatcher was never mounted)

#### Test plan
- [x] `cd app/web/frontend && pnpm check`
- [x] `cd app/web/frontend && pnpm test`
- [ ] Optional: toggle dark mode and trigger a refresh toast

Generated with [Devin](https://devin.ai)