### PR TITLE
fix(web): surface cert load failures in refresh toast

### DIFF
--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -144,7 +144,11 @@
 
     void (async () => {
       await i18n.ready
-      await load(true)
+      try {
+        await load(true)
+      } catch {
+        // Hard cert failure: ErrorBanner shows certs.error; avoid unhandled rejection.
+      }
     })()
     const id = setInterval(() => {
       if (tabVisible()) void status.refresh()
@@ -156,7 +160,11 @@
   $effect(() => {
     if (autoRefreshSec <= 0) return
     const id = setInterval(() => {
-      if (tabVisible() && !certs.loading) void load()
+      if (tabVisible() && !certs.loading) {
+        void load().catch(() => {
+          // Hard cert failure: ErrorBanner shows certs.error.
+        })
+      }
     }, autoRefreshSec * 1000)
     return () => clearInterval(id)
   })
@@ -190,17 +198,15 @@
       } finally {
         initialLoad = false
       }
-      if (!certs.error) {
-        lastUpdated = new Date()
-        notifyExpiry(true)
-      }
+      if (certs.error) throw new Error(certs.error)
+      lastUpdated = new Date()
+      notifyExpiry(true)
       return
     }
     await Promise.all(promises)
-    if (!certs.error) {
-      lastUpdated = new Date()
-      notifyExpiry(false)
-    }
+    if (certs.error) throw new Error(certs.error)
+    lastUpdated = new Date()
+    notifyExpiry(false)
   }
 
   /**
@@ -237,7 +243,8 @@
     toast.promise(load(), {
       loading: i18n.t('toastRefreshing', 'Refreshing…'),
       success: () => i18n.t('loadSuccess', 'Certificates loaded'),
-      error: i18n.t('toastRefreshFailed', 'Refresh failed'),
+      error: (err) =>
+        err instanceof Error ? err.message : i18n.t('toastRefreshFailed', 'Refresh failed'),
     })
   }
 


### PR DESCRIPTION
## Summary
- Manual refresh used `toast.promise(load())`, but `certs.refresh()` catches errors into store state and never rejects, so Sonner almost always showed success even when the load failed.
- `load()` now throws when `certs.error` is set so the toast error path runs (with the store message when available).
- Initial/auto-refresh callers catch the rejection so the shell stays usable and ErrorBanner remains the primary surface outside manual refresh.

#### Test plan
- [x] `make web-check`
- [x] `make web-test`
- [ ] Manual: stop backend → click refresh → failed toast + error banner (not success)

Plan: 007-fix-refresh-toast-and-load-errors

Generated with [Devin](https://devin.ai)