### PR TITLE
fix(web): ignore stale certificate list responses

### DIFF
--- a/app/web/frontend/src/lib/stores/certs.svelte.ts
+++ b/app/web/frontend/src/lib/stores/certs.svelte.ts
@@ -17,16 +17,21 @@ export function createCertsStore(i18n: I18nStore): CertsStore {
   let loading = $state(false)
   let error = $state<string | null>(null)
   let lastFetched = $state<Date | null>(null)
+  /** Ignores out-of-order list responses when refreshes overlap. */
+  let refreshGen = 0
 
   async function refresh(mounts?: string[]): Promise<void> {
+    const gen = ++refreshGen
     loading = true
     error = null
     try {
       const envelope = await api.listCertificates(mounts)
+      if (gen !== refreshGen) return
       certificates = envelope.certificates ?? []
       vaultErrors = envelope.errors ?? []
       lastFetched = new Date()
     } catch (err: unknown) {
+      if (gen !== refreshGen) return
       error =
         err instanceof ApiError
           ? err.message
@@ -34,7 +39,8 @@ export function createCertsStore(i18n: I18nStore): CertsStore {
       certificates = []
       vaultErrors = []
     } finally {
-      loading = false
+      // Only the latest in-flight request may clear loading.
+      if (gen === refreshGen) loading = false
     }
   }
 

--- a/app/web/frontend/src/lib/stores/certs.test.ts
+++ b/app/web/frontend/src/lib/stores/certs.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Certificate, CertificatesEnvelope } from '$lib/types'
+
+const { listCertificates, ApiError } = vi.hoisted(() => {
+  class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+      this.name = 'ApiError'
+    }
+  }
+  return {
+    listCertificates: vi.fn(),
+    ApiError,
+  }
+})
+
+vi.mock('$lib/api', () => ({
+  api: { listCertificates },
+  ApiError,
+}))
+
+import { createCertsStore } from '$lib/stores/certs.svelte'
+import type { I18nStore } from '$lib/stores/i18n.svelte'
+
+const i18n = {
+  t: (_key: string, fallback?: string) => fallback ?? _key,
+} as unknown as I18nStore
+
+function sampleCert(id: string): Certificate {
+  return {
+    id,
+    serialNumber: '1',
+    commonName: id,
+    sans: [],
+    certType: 'machine',
+    createdAt: '2024-01-01T00:00:00Z',
+    expiresAt: '2030-01-01T00:00:00Z',
+    revoked: false,
+  }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (err: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (err: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  listCertificates.mockReset()
+})
+
+describe('createCertsStore', () => {
+  it('loads certificates on refresh', async () => {
+    const envelope: CertificatesEnvelope = {
+      certificates: [sampleCert('a')],
+      errors: [],
+    }
+    listCertificates.mockResolvedValueOnce(envelope)
+    const store = createCertsStore(i18n)
+    await store.refresh()
+    expect(store.certificates).toEqual(envelope.certificates)
+    expect(store.error).toBeNull()
+    expect(store.loading).toBe(false)
+  })
+
+  it('ignores a stale slower response after a newer refresh wins', async () => {
+    const first = deferred<CertificatesEnvelope>()
+    const second = deferred<CertificatesEnvelope>()
+    listCertificates.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    const store = createCertsStore(i18n)
+    const p1 = store.refresh()
+    const p2 = store.refresh()
+
+    second.resolve({
+      certificates: [sampleCert('newer')],
+      errors: [],
+    })
+    await p2
+    expect(store.certificates.map((c) => c.id)).toEqual(['newer'])
+    expect(store.loading).toBe(false)
+
+    first.resolve({
+      certificates: [sampleCert('stale')],
+      errors: [],
+    })
+    await p1
+    expect(store.certificates.map((c) => c.id)).toEqual(['newer'])
+    expect(store.loading).toBe(false)
+  })
+
+  it('does not apply a stale error after a successful newer refresh', async () => {
+    const first = deferred<CertificatesEnvelope>()
+    const second = deferred<CertificatesEnvelope>()
+    listCertificates.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    const store = createCertsStore(i18n)
+    const p1 = store.refresh()
+    const p2 = store.refresh()
+
+    second.resolve({
+      certificates: [sampleCert('ok')],
+      errors: [],
+    })
+    await p2
+    expect(store.certificates.map((c) => c.id)).toEqual(['ok'])
+    expect(store.error).toBeNull()
+
+    first.reject(new ApiError(500, 'stale failure'))
+    await p1
+    expect(store.certificates.map((c) => c.id)).toEqual(['ok'])
+    expect(store.error).toBeNull()
+    expect(store.loading).toBe(false)
+  })
+
+  it('keeps loading true until the latest in-flight refresh finishes', async () => {
+    const first = deferred<CertificatesEnvelope>()
+    const second = deferred<CertificatesEnvelope>()
+    listCertificates.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    const store = createCertsStore(i18n)
+    const p1 = store.refresh()
+    const p2 = store.refresh()
+    expect(store.loading).toBe(true)
+
+    first.resolve({ certificates: [sampleCert('stale')], errors: [] })
+    await p1
+    expect(store.loading).toBe(true)
+
+    second.resolve({ certificates: [sampleCert('latest')], errors: [] })
+    await p2
+    expect(store.loading).toBe(false)
+    expect(store.certificates.map((c) => c.id)).toEqual(['latest'])
+  })
+})


### PR DESCRIPTION
## Summary
- Concurrent `certs.refresh()` calls (manual, auto-refresh, initial) had no sequencing, so an older HTTP response could overwrite a fresher list and flip `loading` off early.
- Add a generation counter (same idea as `CertDetailModal` request IDs): only the latest generation may write certificates/errors or clear loading.
- Unit tests cover out-of-order success, stale error, and loading semantics.

#### Test plan
- [x] `pnpm test` (includes new `certs.test.ts`)
- [x] `pnpm check`

Plan: 008-certs-store-stale-refresh-guard

Generated with [Devin](https://devin.ai)