### PR TITLE
fix(web): refresh public config thresholds on each load

### DIFF
--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -190,23 +190,21 @@
   })
 
   async function load(initial = false): Promise<void> {
-    const promises: Promise<void>[] = [certs.refresh(), status.refresh()]
+    // Always reload public config so admin threshold edits land without a full page reload.
+    const promises: Promise<void>[] = [certs.refresh(), status.refresh(), config.refresh()]
     if (initial) {
-      promises.push(config.refresh())
       try {
         await Promise.all(promises)
       } finally {
         initialLoad = false
       }
-      if (certs.error) throw new Error(certs.error)
-      lastUpdated = new Date()
-      notifyExpiry(true)
-      return
+    } else {
+      await Promise.all(promises)
     }
-    await Promise.all(promises)
+    // Config failure keeps last-good thresholds (config store). Cert hard-fail rejects for toast.
     if (certs.error) throw new Error(certs.error)
     lastUpdated = new Date()
-    notifyExpiry(false)
+    notifyExpiry(initial)
   }
 
   /**


### PR DESCRIPTION
## Summary
- Dashboard only fetched `/api/config` on initial `load(true)`, so admin changes to expiration thresholds left StatusOverview labels and filters stale until full reload.
- Always include `config.refresh()` with certs/status on every load (manual + auto-refresh).
- Config failure still keeps last-good thresholds (store behavior) and does not blank certificates.

#### Test plan
- [x] `make web-check`
- [x] `make web-test`
- [ ] Manual: change thresholds in admin → refresh dashboard without full reload → StatusOverview day labels update

Plan: 009-reload-config-on-refresh

Generated with [Devin](https://devin.ai)