### PR TITLE
fix(web): surface admin logout and mutation API errors

### DIFF
--- a/app/internal/i18n/i18n.go
+++ b/app/internal/i18n/i18n.go
@@ -127,6 +127,7 @@ type Messages struct {
 	AdminTitle                  string `json:"adminTitle"`
 	AdminBackToVCV              string `json:"adminBackToVCV"`
 	AdminSettingsSaved          string `json:"adminSettingsSaved"`
+	AdminLogoutFailed           string `json:"adminLogoutFailed"`
 	AdminLogout                 string `json:"adminLogout"`
 	AdminLogin                  string `json:"adminLogin"`
 	AdminPassword               string `json:"adminPassword"`
@@ -335,6 +336,7 @@ var englishMessages = Messages{
 	AdminTitle:                     "VaultCertsViewer Admin",
 	AdminBackToVCV:                 "Back to VCV",
 	AdminSettingsSaved:             "Settings saved",
+	AdminLogoutFailed:              "Logout failed",
 	AdminLogout:                    "Logout",
 	AdminLogin:                     "Login",
 	AdminPassword:                  "Password",
@@ -533,6 +535,7 @@ var frenchMessages = Messages{
 	AdminTitle:                     "VaultCertsViewer Admin",
 	AdminBackToVCV:                 "Retour à VCV",
 	AdminSettingsSaved:             "Paramètres enregistrés",
+	AdminLogoutFailed:              "Échec de la déconnexion",
 	AdminLogout:                    "Déconnexion",
 	AdminLogin:                     "Connexion",
 	AdminPassword:                  "Mot de passe",
@@ -731,6 +734,7 @@ var spanishMessages = Messages{
 	AdminTitle:                     "VaultCertsViewer Admin",
 	AdminBackToVCV:                 "Volver a VCV",
 	AdminSettingsSaved:             "Configuración guardada",
+	AdminLogoutFailed:              "Error al cerrar sesión",
 	AdminLogout:                    "Cerrar sesión",
 	AdminLogin:                     "Iniciar sesión",
 	AdminPassword:                  "Contraseña",
@@ -929,6 +933,7 @@ var germanMessages = Messages{
 	AdminTitle:                     "VaultCertsViewer Admin",
 	AdminBackToVCV:                 "Zurück zu VCV",
 	AdminSettingsSaved:             "Einstellungen gespeichert",
+	AdminLogoutFailed:              "Abmelden fehlgeschlagen",
 	AdminLogout:                    "Abmelden",
 	AdminLogin:                     "Anmelden",
 	AdminPassword:                  "Passwort",
@@ -1127,6 +1132,7 @@ var italianMessages = Messages{
 	AdminTitle:                     "VaultCertsViewer Admin",
 	AdminBackToVCV:                 "Torna a VCV",
 	AdminSettingsSaved:             "Impostazioni salvate",
+	AdminLogoutFailed:              "Disconnessione non riuscita",
 	AdminLogout:                    "Disconnetti",
 	AdminLogin:                     "Accedi",
 	AdminPassword:                  "Password",

--- a/app/web/frontend/src/lib/api.ts
+++ b/app/web/frontend/src/lib/api.ts
@@ -23,8 +23,20 @@ export class ApiError extends Error {
   }
 }
 
+async function parseErrorMessage(response: Response, path: string, method: string): Promise<string> {
+  let message = `${method} ${path} failed: ${response.status}`
+  try {
+    const body = (await response.json()) as { error?: string }
+    if (body?.error) message = body.error
+  } catch {
+    // non-JSON body
+  }
+  return message
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const { headers: initHeaders, ...restInit } = init ?? {}
+  const method = init?.method ?? 'GET'
   const response = await fetch(path, {
     credentials: 'same-origin',
     ...restInit,
@@ -34,16 +46,26 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     },
   })
   if (!response.ok) {
-    let message = `${init?.method ?? 'GET'} ${path} failed: ${response.status}`
-    try {
-      const body = (await response.json()) as { error?: string }
-      if (body?.error) message = body.error
-    } catch {
-      // non-JSON body
-    }
-    throw new ApiError(response.status, message)
+    throw new ApiError(response.status, await parseErrorMessage(response, path, method))
   }
   return (await response.json()) as T
+}
+
+/** POST/DELETE with no response body on success; still parses body.error on failure. */
+async function requestVoid(path: string, init?: RequestInit): Promise<void> {
+  const { headers: initHeaders, ...restInit } = init ?? {}
+  const method = init?.method ?? 'GET'
+  const response = await fetch(path, {
+    credentials: 'same-origin',
+    ...restInit,
+    headers: {
+      Accept: 'application/json',
+      ...(initHeaders ?? {}),
+    },
+  })
+  if (!response.ok) {
+    throw new ApiError(response.status, await parseErrorMessage(response, path, method))
+  }
 }
 
 export const api = {
@@ -86,8 +108,8 @@ export const api = {
       body: JSON.stringify({ username, password }),
     })
   },
-  async adminLogout(): Promise<void> {
-    await fetch('/api/admin/logout', { method: 'POST', credentials: 'same-origin' })
+  adminLogout(): Promise<void> {
+    return requestVoid('/api/admin/logout', { method: 'POST' })
   },
   adminGetSettings(): Promise<AdminSettingsResponse> {
     return request<AdminSettingsResponse>('/api/admin/settings')
@@ -102,22 +124,10 @@ export const api = {
   adminAddVault(): Promise<AdminVaultAddedResponse> {
     return request<AdminVaultAddedResponse>('/api/admin/vault', { method: 'POST' })
   },
-  async adminDeleteVault(id: string): Promise<void> {
-    const response = await fetch(`/api/admin/vault/${encodeURIComponent(id)}`, {
-      method: 'DELETE',
-      credentials: 'same-origin',
-    })
-    if (!response.ok) {
-      throw new ApiError(response.status, `DELETE /api/admin/vault/${id} failed`)
-    }
+  adminDeleteVault(id: string): Promise<void> {
+    return requestVoid(`/api/admin/vault/${encodeURIComponent(id)}`, { method: 'DELETE' })
   },
-  async adminInvalidateCache(): Promise<void> {
-    const response = await fetch('/api/cache/invalidate', {
-      method: 'POST',
-      credentials: 'same-origin',
-    })
-    if (!response.ok) {
-      throw new ApiError(response.status, 'cache invalidate failed')
-    }
+  adminInvalidateCache(): Promise<void> {
+    return requestVoid('/api/cache/invalidate', { method: 'POST' })
   },
 }

--- a/app/web/frontend/src/lib/stores/admin.svelte.ts
+++ b/app/web/frontend/src/lib/stores/admin.svelte.ts
@@ -69,10 +69,17 @@ export function createAdminStore(i18n: I18nStore): AdminStore {
   }
 
   async function logout(): Promise<void> {
-    await api.adminLogout()
-    authenticated = false
-    settings = null
-    vaultStatuses = []
+    try {
+      await api.adminLogout()
+      authenticated = false
+      settings = null
+      vaultStatuses = []
+      error = null
+    } catch (err: unknown) {
+      // Keep local session until server logout succeeds so a failed CSRF/network
+      // call does not leave the user believing they are signed out.
+      applyError(err, i18n.t('adminLogoutFailed', 'Logout failed'))
+    }
   }
 
   async function loadSettings(): Promise<void> {

--- a/app/web/frontend/src/lib/stores/admin.test.ts
+++ b/app/web/frontend/src/lib/stores/admin.test.ts
@@ -174,6 +174,22 @@ describe('createAdminStore', () => {
     expect(store.vaultStatuses).toEqual([])
   })
 
+  it('logout failure keeps authenticated and sets error', async () => {
+    const store = createAdminStore(i18n)
+    adminLogin.mockResolvedValueOnce({ authenticated: true })
+    await store.login('admin', 'secret')
+    adminGetSettings.mockResolvedValueOnce({
+      settings: sampleSettings([sampleVault()]),
+      vault_statuses: [],
+    })
+    await store.loadSettings()
+    adminLogout.mockRejectedValueOnce(new ApiError(403, 'CSRF validation failed'))
+    await store.logout()
+    expect(store.authenticated).toBe(true)
+    expect(store.settings).not.toBeNull()
+    expect(store.error).toBe('CSRF validation failed')
+  })
+
   it('invalidateCache sets successMessage on success', async () => {
     const store = createAdminStore(i18n)
     adminInvalidateCache.mockResolvedValueOnce(undefined)


### PR DESCRIPTION
## Summary
- `adminLogout` ignored `response.ok` and the store always cleared local auth, so a CSRF/network failure could look like a successful logout while the session cookie remained.
- DELETE vault / cache invalidate threw generic status strings and ignored backend `body.error`.
- Shared `requestVoid` parses failure bodies like `request()`, and logout only clears client state when the server accepts logout. Adds `adminLogoutFailed` i18n across en/fr/es/de/it.

#### Test plan
- [x] Admin store tests (success + failed logout)
- [x] `pnpm check` / `pnpm test`
- [x] `go test ./internal/i18n/...`

Plan: 010-admin-api-error-parity

Generated with [Devin](https://devin.ai)