### PR TITLE
fix(web): treat unparseable cert expiry as expired

### DIFF
--- a/app/web/frontend/src/lib/utils/cert-status.test.ts
+++ b/app/web/frontend/src/lib/utils/cert-status.test.ts
@@ -46,6 +46,13 @@ describe('certStatus', () => {
     expect(certStatus(cert('2026-06-24T00:00:00Z'), undefined, NOW)).toBe('critical') // exactly 7d
     expect(certStatus(cert('2026-07-17T00:00:00Z'), undefined, NOW)).toBe('warning') // exactly 30d
   })
+
+  it('treats empty or unparseable expiresAt as expired', () => {
+    expect(certStatus(cert(''), undefined, NOW)).toBe('expired')
+    expect(certStatus(cert('not-a-date'), undefined, NOW)).toBe('expired')
+    expect(Number.isNaN(daysUntilExpiry(cert(''), NOW))).toBe(true)
+    expect(Number.isNaN(daysUntilExpiry(cert('not-a-date'), NOW))).toBe(true)
+  })
 })
 
 describe('class helpers', () => {

--- a/app/web/frontend/src/lib/utils/cert-status.ts
+++ b/app/web/frontend/src/lib/utils/cert-status.ts
@@ -7,6 +7,7 @@ export const DEFAULT_THRESHOLDS: ExpirationThresholds = {
 
 export function daysUntilExpiry(cert: Certificate, now: Date = new Date()): number {
   const expires = new Date(cert.expiresAt).getTime()
+  if (!Number.isFinite(expires)) return Number.NaN
   return Math.floor((expires - now.getTime()) / (1000 * 60 * 60 * 24))
 }
 
@@ -17,6 +18,8 @@ export function certStatus(
 ): CertStatus {
   if (cert.revoked) return 'revoked'
   const days = daysUntilExpiry(cert, now)
+  // Unknown expiry is treated as expired for safety (NaN never compares as < or <=).
+  if (!Number.isFinite(days)) return 'expired'
   if (days < 0) return 'expired'
   if (days <= thresholds.critical) return 'critical'
   if (days <= thresholds.warning) return 'warning'


### PR DESCRIPTION
## Summary
- Empty/garbage `expiresAt` values produced NaN day counts; NaN comparisons are always false, so `certStatus` returned `valid`.
- Return NaN from `daysUntilExpiry` for non-finite dates and classify non-finite days as `expired` (safety bias without a new status enum).
- Tests cover empty and unparseable dates.

#### Test plan
- [x] `pnpm test` (cert-status + full suite)
- [x] `pnpm check`

Plan: 011-cert-status-invalid-dates

Generated with [Devin](https://devin.ai)