### PR TITLE
fix(middleware): gate X-Forwarded-* on trust_proxy config

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -148,6 +148,14 @@ vcv is designed for **private networks**. Do not expose the listen port to the p
 - Security headers, body size limits, request IDs.
 - Public `/api/status` error strings are sanitized (no raw Vault internals).
 
+### Reverse proxy / `trust_proxy`
+
+Rate limiting keys and CSRF target-origin construction honor `X-Forwarded-For`, `X-Forwarded-Host`, and `X-Forwarded-Proto` **only** when `app.trust_proxy` is `true` (default **`false`**).
+
+Set `app.trust_proxy: true` **only** when a reverse proxy (nginx, Traefik, etc.) sits in front of vcv and **overwrites** client-supplied `X-Forwarded-*` headers with trusted values. If clients can reach vcv directly while this flag is true, they can spoof per-IP rate-limit buckets and skew CSRF origin checks.
+
+Lab `docker-compose` without a stripping proxy should leave `trust_proxy` false.
+
 ## Logging
 
 - Initialized in `cmd/server/main.go` via `internal/logger.Init`.

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -121,9 +121,10 @@ func buildRouter(cfg config.Config, primaryVaultClient vault.Client, statusClien
 	rateLimitConfig.Window = routerRateLimitWindow
 	rateLimitConfig.ExemptPaths = []string{"/api/health", "/api/ready", "/metrics"}
 	rateLimitConfig.ExemptPathPrefixes = []string{"/assets/"}
+	rateLimitConfig.TrustProxy = cfg.TrustProxy
 	r.Use(middleware.RateLimit(rateLimitConfig))
 	r.Use(middleware.BodyLimit(routerMaxBodyBytes))
-	r.Use(middleware.CSRFProtection)
+	r.Use(middleware.CSRFProtectionWithTrust(cfg.TrustProxy))
 
 	handlers.RegisterStaticRoutes(r, distFS)
 

--- a/app/internal/config/config.go
+++ b/app/internal/config/config.go
@@ -26,7 +26,11 @@ type Config struct {
 	LogOutput    string
 	LogFilePath  string
 	SettingsPath string
-	CORS         CORSConfig
+	// TrustProxy enables honoring X-Forwarded-For / X-Forwarded-Host / X-Forwarded-Proto
+	// for client IP (rate limits) and CSRF target origin. Enable only behind a reverse
+	// proxy that overwrites those headers; default false (fail-closed).
+	TrustProxy bool
+	CORS       CORSConfig
 	// Vault is deprecated; prefer Vaults / AllVaults. Kept for legacy logging and helpers.
 	Vault                VaultConfig
 	Vaults               []VaultInstance
@@ -75,9 +79,10 @@ type SettingsFile struct {
 }
 
 type AppSettings struct {
-	Env     string          `json:"env"`
-	Logging LoggingSettings `json:"logging"`
-	Port    int             `json:"port"`
+	Env        string          `json:"env"`
+	Logging    LoggingSettings `json:"logging"`
+	Port       int             `json:"port"`
+	TrustProxy bool            `json:"trust_proxy"`
 }
 
 type LoggingSettings struct {
@@ -216,6 +221,7 @@ func buildConfigFromSettings(settings SettingsFile) Config {
 		LogFormat:            logFormat,
 		LogOutput:            logOutput,
 		LogFilePath:          logFilePath,
+		TrustProxy:           settings.App.TrustProxy,
 		CORS:                 cors,
 		Vault:                VaultConfig{},
 		Vaults:               []VaultInstance{},

--- a/app/internal/config/config_test.go
+++ b/app/internal/config/config_test.go
@@ -146,6 +146,41 @@ func TestLoadFromSettingsFile(t *testing.T) {
 	if cfg.Metrics.EnhancedMetrics {
 		t.Fatalf("expected enhanced metrics false, got %v", cfg.Metrics.EnhancedMetrics)
 	}
+	if cfg.TrustProxy {
+		t.Fatalf("expected TrustProxy false when omitted, got true")
+	}
+}
+
+func TestLoad_TrustProxyTrue(t *testing.T) {
+	tmpDir := t.TempDir()
+	settingsFile := filepath.Join(tmpDir, "settings.json")
+	settingsContent := `{
+		"app": {
+			"env": "dev",
+			"port": 52000,
+			"trust_proxy": true,
+			"logging": {"level": "debug", "format": "console", "output": "stdout"}
+		},
+		"vaults": []
+	}`
+	if err := os.WriteFile(settingsFile, []byte(settingsContent), 0644); err != nil {
+		t.Fatalf("failed to create test settings file: %v", err)
+	}
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(originalWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.TrustProxy {
+		t.Fatalf("expected TrustProxy true when set, got false")
+	}
 }
 
 func TestLoadSettingsFile_MissingFile(t *testing.T) {

--- a/app/internal/middleware/middleware.go
+++ b/app/internal/middleware/middleware.go
@@ -195,59 +195,74 @@ func sanitizeRequestID(value string) string {
 	return trimmed
 }
 
+// CSRFProtection is CSRF middleware with trustProxy=false (fail-closed on X-Forwarded-*).
 func CSRFProtection(next http.Handler) http.Handler {
+	return CSRFProtectionWithTrust(false)(next)
+}
+
+// CSRFProtectionWithTrust returns CSRF middleware. When trustProxy is true,
+// target origin prefers X-Forwarded-Host / X-Forwarded-Proto (for reverse proxies
+// that overwrite those headers). When false, only r.Host and TLS/http are used.
+func CSRFProtectionWithTrust(trustProxy bool) func(http.Handler) http.Handler {
 	safeMethods := map[string]struct{}{http.MethodGet: {}, http.MethodHead: {}, http.MethodOptions: {}}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if _, ok := safeMethods[r.Method]; ok {
-			next.ServeHTTP(w, r)
-			return
-		}
-		fetchSite := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")))
-		// Only block cross-site requests; allow same-site and same-origin.
-		// This is necessary for reverse proxy deployments where the browser
-		// may categorize requests as same-site rather than same-origin.
-		if fetchSite == "cross-site" {
-			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-			return
-		}
-		origin := strings.TrimSpace(r.Header.Get("Origin"))
-		if origin != "" {
-			if sameOrigin(origin, targetOrigin(r)) {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, ok := safeMethods[r.Method]; ok {
 				next.ServeHTTP(w, r)
 				return
 			}
-			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-			return
-		}
-		referer := strings.TrimSpace(r.Header.Get("Referer"))
-		if referer != "" {
-			parsed, err := url.Parse(referer)
-			if err == nil {
-				refererOrigin := parsed.Scheme + "://" + parsed.Host
-				if sameOrigin(refererOrigin, targetOrigin(r)) {
+			fetchSite := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")))
+			// Only block cross-site requests; allow same-site and same-origin.
+			// This is necessary for reverse proxy deployments where the browser
+			// may categorize requests as same-site rather than same-origin.
+			if fetchSite == "cross-site" {
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
+			origin := strings.TrimSpace(r.Header.Get("Origin"))
+			if origin != "" {
+				if sameOrigin(origin, targetOrigin(r, trustProxy)) {
 					next.ServeHTTP(w, r)
 					return
 				}
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
 			}
-			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-			return
-		}
-		// Cookie-bearing unsafe methods without Origin/Referer are likely
-		// browser session CSRF; allow only cookieless non-browser clients.
-		if hasCookies(r) {
-			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
+			referer := strings.TrimSpace(r.Header.Get("Referer"))
+			if referer != "" {
+				parsed, err := url.Parse(referer)
+				if err == nil {
+					refererOrigin := parsed.Scheme + "://" + parsed.Host
+					if sameOrigin(refererOrigin, targetOrigin(r, trustProxy)) {
+						next.ServeHTTP(w, r)
+						return
+					}
+				}
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
+			// Cookie-bearing unsafe methods without Origin/Referer are likely
+			// browser session CSRF; allow only cookieless non-browser clients.
+			if hasCookies(r) {
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func hasCookies(r *http.Request) bool {
 	return strings.TrimSpace(r.Header.Get("Cookie")) != ""
 }
 
-func targetOrigin(r *http.Request) string {
-	proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+func targetOrigin(r *http.Request, trustProxy bool) string {
+	proto := ""
+	host := ""
+	if trustProxy {
+		proto = strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+		host = strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	}
 	if proto == "" {
 		if r.TLS != nil {
 			proto = "https"
@@ -255,7 +270,6 @@ func targetOrigin(r *http.Request) string {
 			proto = "http"
 		}
 	}
-	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
 	if host == "" {
 		host = strings.TrimSpace(r.Host)
 	}
@@ -289,6 +303,9 @@ type RateLimitConfig struct {
 	MaxEntries         int
 	ExemptPaths        []string
 	ExemptPathPrefixes []string
+	// TrustProxy controls whether ClientIP honors X-Forwarded-For / X-Real-IP.
+	// Default false: key on RemoteAddr only (fail-closed without a stripping proxy).
+	TrustProxy bool
 }
 
 type rateLimiterEntry struct {
@@ -318,7 +335,7 @@ func RateLimit(config RateLimitConfig) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			allowed, retryAfter := limiter.allow(time.Now(), httputil.ClientIP(r, true))
+			allowed, retryAfter := limiter.allow(time.Now(), httputil.ClientIP(r, config.TrustProxy))
 			if !allowed {
 				if retryAfter > 0 {
 					w.Header().Set("Retry-After", strconv.Itoa(retryAfter))

--- a/app/internal/middleware/middleware_test.go
+++ b/app/internal/middleware/middleware_test.go
@@ -1,6 +1,7 @@
 package middleware_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -184,6 +185,83 @@ func TestRateLimit_BlocksAfterThreshold_EmptyIP(t *testing.T) {
 		if rec.Code != http.StatusTooManyRequests {
 			t.Fatalf("expected status %d, got %d", http.StatusTooManyRequests, rec.Code)
 		}
+	}
+}
+
+func TestRateLimit_TrustProxyFalse_IgnoresXForwardedFor(t *testing.T) {
+	config := middleware.DefaultRateLimitConfig()
+	config.MaxRequests = 1
+	config.Window = 10 * time.Second
+	config.TrustProxy = false
+	h := middleware.RateLimit(config)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	// Same RemoteAddr, different XFF — without trust must share one bucket.
+	for i := range 2 {
+		req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = "192.0.2.10:1234"
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("203.0.113.%d", i+1))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if i == 0 && rec.Code != http.StatusNoContent {
+			t.Fatalf("request %d: expected %d, got %d", i, http.StatusNoContent, rec.Code)
+		}
+		if i == 1 && rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("request %d: expected %d, got %d", i, http.StatusTooManyRequests, rec.Code)
+		}
+	}
+}
+
+func TestRateLimit_TrustProxyTrue_UsesXForwardedFor(t *testing.T) {
+	config := middleware.DefaultRateLimitConfig()
+	config.MaxRequests = 1
+	config.Window = 10 * time.Second
+	config.TrustProxy = true
+	h := middleware.RateLimit(config)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	// Same RemoteAddr, different XFF — with trust should get separate buckets.
+	for i := range 2 {
+		req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+		req.RemoteAddr = "192.0.2.10:1234"
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("203.0.113.%d", i+1))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("request %d: expected separate bucket OK, got %d", i, rec.Code)
+		}
+	}
+}
+
+func TestCSRFProtectionWithTrust_UsesForwardedHostWhenTrusted(t *testing.T) {
+	h := middleware.CSRFProtectionWithTrust(true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "http://backend.internal/admin/login", strings.NewReader(""))
+	req.Host = "backend.internal"
+	req.Header.Set("X-Forwarded-Host", "app.example.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("Origin", "https://app.example.com")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected status %d when trusted forwarded host matches Origin, got %d", http.StatusNoContent, rec.Code)
+	}
+}
+
+func TestCSRFProtectionWithTrust_IgnoresForwardedHostWhenUntrusted(t *testing.T) {
+	h := middleware.CSRFProtectionWithTrust(false)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "http://backend.internal/admin/login", strings.NewReader(""))
+	req.Host = "backend.internal"
+	req.Header.Set("X-Forwarded-Host", "app.example.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("Origin", "https://app.example.com")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status %d when untrusted X-Forwarded-* skews origin, got %d", http.StatusForbidden, rec.Code)
 	}
 }
 

--- a/settings.enhanced-metrics.example.json
+++ b/settings.enhanced-metrics.example.json
@@ -1,6 +1,7 @@
 {
   "app": {
     "env": "prod",
+    "trust_proxy": false,
     "port": 52000,
     "logging": {
       "level": "info",

--- a/settings.example.json
+++ b/settings.example.json
@@ -4,6 +4,7 @@
   },
   "app": {
     "env": "prod",
+    "trust_proxy": false,
     "logging": {
       "level": "info",
       "format": "json",


### PR DESCRIPTION
## Summary
- Add `app.trust_proxy` (default `false`) so RateLimit ClientIP and CSRF target origin only honor `X-Forwarded-*` when a reverse proxy overwrites those headers.
- Wire config into `RateLimitConfig.TrustProxy` and `CSRFProtectionWithTrust`.
- Document setting in README and example settings files; add unit tests.

#### Test plan
- [x] `cd app && go test ./internal/middleware/ ./internal/httputil/ ./internal/config/ ./cmd/server/ -count=1`
- [ ] Behind a real reverse proxy: set `trust_proxy: true` and confirm login/rate-limit still work

Generated with [Devin](https://devin.ai)