### PR TITLE
fix(admin): log when admin routes are not registered

### DIFF
--- a/app/internal/handlers/admin.go
+++ b/app/internal/handlers/admin.go
@@ -342,20 +342,29 @@ func newVaultKey() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
+// isBcryptHash reports whether s looks like a bcrypt hash ($2a$/$2b$/$2y$).
+func isBcryptHash(s string) bool {
+	return strings.HasPrefix(s, "$2a$") || strings.HasPrefix(s, "$2b$") || strings.HasPrefix(s, "$2y$")
+}
+
 // RegisterAdminRoutes wires the JSON admin API. HTMX routes have been removed
 // in favor of the Svelte admin panel that talks to /api/admin/*.
+// Admin remains optional: missing/invalid password skips registration with a clear log.
 func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Environment, vaultRegistry *vault.Registry, vaultStatusClients map[string]vault.Client, cacheClient vault.Client) {
 	settingsStore := newAdminSettingsStore(settingsPath, env)
 	settings, err := settingsStore.load()
 	if err != nil {
+		logger.Get().Warn().Err(err).Msg("admin API disabled: settings load failed")
 		return
 	}
 
 	password := strings.TrimSpace(settings.Admin.Password)
 	if password == "" {
+		logger.Get().Info().Msg("admin API disabled: admin.password empty")
 		return
 	}
-	if !strings.HasPrefix(password, "$2a$") && !strings.HasPrefix(password, "$2b$") && !strings.HasPrefix(password, "$2y$") {
+	if !isBcryptHash(password) {
+		logger.Get().Warn().Msg("admin API disabled: admin.password is not a bcrypt hash")
 		return
 	}
 
@@ -388,4 +397,5 @@ func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Envi
 				Msg("invalidated cache")
 		})
 	})
+	logger.Get().Info().Msg("admin API enabled")
 }

--- a/app/internal/handlers/admin_test.go
+++ b/app/internal/handlers/admin_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -569,6 +570,55 @@ func TestRegisterAdminRoutes(t *testing.T) {
 
 	// Verify routes are registered
 	assert.NotNil(t, r)
+}
+
+func TestIsBcryptHash(t *testing.T) {
+	assert.True(t, isBcryptHash("$2a$10$abcdefghijklmnopqrstuu"))
+	assert.True(t, isBcryptHash("$2b$10$abcdefghijklmnopqrstuu"))
+	assert.True(t, isBcryptHash("$2y$10$abcdefghijklmnopqrstuu"))
+	assert.False(t, isBcryptHash(""))
+	assert.False(t, isBcryptHash("plaintext"))
+	assert.False(t, isBcryptHash("$1$notbcrypt"))
+}
+
+func TestRegisterAdminRoutes_EmptyPassword_LoginNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	settingsPath := tmpDir + "/settings.json"
+	settings := config.SettingsFile{
+		App:   config.AppSettings{Env: "dev", Port: 52000},
+		Admin: config.AdminSettings{Password: ""},
+	}
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
+
+	r := chi.NewRouter()
+	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/login", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRegisterAdminRoutes_InvalidHash_LoginNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	settingsPath := tmpDir + "/settings.json"
+	settings := config.SettingsFile{
+		App:   config.AppSettings{Env: "dev", Port: 52000},
+		Admin: config.AdminSettings{Password: "not-a-bcrypt-hash"},
+	}
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
+
+	r := chi.NewRouter()
+	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/login", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestRegisterAdminRoutes_CacheInvalidate(t *testing.T) {


### PR DESCRIPTION
## Summary
- Log Warn/Info when admin API is not registered (settings load failure, empty password, non-bcrypt hash).
- Optional Info when admin API is enabled.
- Extract `isBcryptHash` helper; tests for empty/invalid password leave login 404.

#### Test plan
- [x] `cd app && go test ./internal/handlers/ -count=1 -run 'Admin|IsBcrypt'`

Generated with [Devin](https://devin.ai)