### PR TITLE
fix(admin): treat masked vault token placeholders as blank

### DIFF
--- a/app/internal/handlers/admin_api.go
+++ b/app/internal/handlers/admin_api.go
@@ -258,6 +258,23 @@ func maskVaultTokens(s config.SettingsFile) config.SettingsFile {
 	return out
 }
 
+// isBlankOrMaskedToken reports whether token is empty or a common UI mask
+// sentinel that must not overwrite a stored Vault token on admin PUT.
+func isBlankOrMaskedToken(token string) bool {
+	t := strings.TrimSpace(token)
+	if t == "" {
+		return true
+	}
+	switch t {
+	case "***", "********", "••••••••", "__MASKED__", "[masked]":
+		return true
+	}
+	if strings.Trim(t, "*") == "" && len(t) >= 3 {
+		return true
+	}
+	return false
+}
+
 func mergeVaultTokens(incoming, existing []config.VaultInstance) []config.VaultInstance {
 	tokens := make(map[string]string, len(existing))
 	for _, v := range existing {
@@ -265,7 +282,7 @@ func mergeVaultTokens(incoming, existing []config.VaultInstance) []config.VaultI
 	}
 	merged := make([]config.VaultInstance, 0, len(incoming))
 	for _, v := range incoming {
-		if strings.TrimSpace(v.Token) == "" {
+		if isBlankOrMaskedToken(v.Token) {
 			lookupKey := v.OriginalID
 			if lookupKey == "" {
 				lookupKey = v.ID

--- a/app/internal/handlers/admin_api_unexported_test.go
+++ b/app/internal/handlers/admin_api_unexported_test.go
@@ -433,6 +433,40 @@ func TestMergeVaultTokens_PreservesEmptyTokens(t *testing.T) {
 	assert.Equal(t, "existing-token", result[0].Token) // Should preserve existing token
 }
 
+func TestIsBlankOrMaskedToken(t *testing.T) {
+	assert.True(t, isBlankOrMaskedToken(""))
+	assert.True(t, isBlankOrMaskedToken("   "))
+	assert.True(t, isBlankOrMaskedToken("***"))
+	assert.True(t, isBlankOrMaskedToken("********"))
+	assert.True(t, isBlankOrMaskedToken("••••••••"))
+	assert.True(t, isBlankOrMaskedToken("__MASKED__"))
+	assert.True(t, isBlankOrMaskedToken("[masked]"))
+	assert.True(t, isBlankOrMaskedToken("*****"))
+	assert.False(t, isBlankOrMaskedToken("s.real-vault-token"))
+	assert.False(t, isBlankOrMaskedToken("hvs.real"))
+	assert.False(t, isBlankOrMaskedToken("*"))  // too short to treat as mask
+	assert.False(t, isBlankOrMaskedToken("**")) // too short
+}
+
+func TestMergeVaultTokens_PreservesMaskedPlaceholders(t *testing.T) {
+	existing := []config.VaultInstance{
+		{ID: "vault1", Address: "http://localhost:8200", Token: "existing-token"},
+	}
+	for _, masked := range []string{"***", "********", "__MASKED__", "[masked]", "••••••••"} {
+		result := mergeVaultTokens([]config.VaultInstance{
+			{ID: "vault1", Address: "http://localhost:8200", Token: masked},
+		}, existing)
+		require.Len(t, result, 1)
+		assert.Equal(t, "existing-token", result[0].Token, "mask %q must preserve stored token", masked)
+	}
+	// Real replacement still applies.
+	result := mergeVaultTokens([]config.VaultInstance{
+		{ID: "vault1", Address: "http://localhost:8200", Token: "brand-new-token"},
+	}, existing)
+	require.Len(t, result, 1)
+	assert.Equal(t, "brand-new-token", result[0].Token)
+}
+
 func TestComputeVaultStatuses(t *testing.T) {
 	settings := config.SettingsFile{
 		Vaults: []config.VaultInstance{


### PR DESCRIPTION
## Summary
- Treat common mask sentinels (`***`, all-asterisk ≥3, `__MASKED__`, etc.) like blank tokens in `mergeVaultTokens` so they do not clobber stored Vault tokens.
- Real non-empty tokens still replace on PUT.

#### Test plan
- [x] `cd app && go test ./internal/handlers/ -count=1 -run 'MergeVault|IsBlankOrMasked|Masked'`

Generated with [Devin](https://devin.ai)