### PR TITLE
fix(admin): key login rate limit by trust_proxy ClientIP

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -121,6 +121,8 @@ vcv is designed for **private networks**. Do not expose the listen port to the p
 | Static SPA `/`, `/admin`, `/assets/*` | Unauthenticated | Admin *API* still requires session |
 | `/api/admin/*` | Session cookie (`vcv_admin_session`) | bcrypt password in settings; disabled if password missing/invalid |
 
+`/api/status` includes `admin_api_enabled` (bool): whether the admin API was registered at process start (valid bcrypt `admin.password`). When false, inventory APIs still run; `/api/ready` stays green (policy B — do not fail readiness solely because admin is off). Startup logs still explain why admin was skipped.
+
 ### What PEMs are
 
 `GET /api/certs/{id}/pem` returns **public** X.509 certificates as stored in Vault PKI. Private keys are never retrieved. Certificate inventories are still sensitive in many organizations.

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -45,7 +45,7 @@ func publicVaultStatusError(err error) string {
 	return "vault unavailable"
 }
 
-func newStatusHandler(cfg config.Config, primaryVaultClient vault.Client, statusClients map[string]vault.Client) http.HandlerFunc {
+func newStatusHandler(cfg config.Config, primaryVaultClient vault.Client, statusClients map[string]vault.Client, adminAPIEnabled bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		type vaultStatusEntry struct {
@@ -55,12 +55,13 @@ func newStatusHandler(cfg config.Config, primaryVaultClient vault.Client, status
 			Error       string `json:"error,omitempty"`
 		}
 		type statusResponse struct {
-			Version        string             `json:"version"`
-			VaultConnected bool               `json:"vault_connected"`
-			VaultError     string             `json:"vault_error,omitempty"`
-			Vaults         []vaultStatusEntry `json:"vaults"`
+			Version         string             `json:"version"`
+			VaultConnected  bool               `json:"vault_connected"`
+			VaultError      string             `json:"vault_error,omitempty"`
+			AdminAPIEnabled bool               `json:"admin_api_enabled"`
+			Vaults          []vaultStatusEntry `json:"vaults"`
 		}
-		response := statusResponse{Version: version.Version, Vaults: make([]vaultStatusEntry, 0, len(cfg.Vaults))}
+		response := statusResponse{Version: version.Version, AdminAPIEnabled: adminAPIEnabled, Vaults: make([]vaultStatusEntry, 0, len(cfg.Vaults))}
 		// Primary connection (historical field) checked in parallel with per-vault checks via helper.
 		primaryClients := map[string]vault.Client{"primary": primaryVaultClient}
 		primaryResults := vault.CheckInstances(ctx, []string{"primary"}, primaryClients, 5*time.Second)
@@ -132,7 +133,9 @@ func buildRouter(cfg config.Config, primaryVaultClient vault.Client, statusClien
 	// Health and readiness probes
 	r.Get("/api/health", handlers.HealthCheck)
 	r.Get("/api/ready", handlers.ReadinessCheck)
-	r.Get("/api/status", newStatusHandler(cfg, primaryVaultClient, statusClients))
+	// Admin is optional; process stays up. Surface enablement on /api/status (not fail-ready).
+	adminAPIEnabled := handlers.RegisterAdminRoutes(r, settingsPath, cfg.Env, vaultRegistry, statusClients, multiVaultClient, cfg.TrustProxy)
+	r.Get("/api/status", newStatusHandler(cfg, primaryVaultClient, statusClients, adminAPIEnabled))
 	r.Get("/api/version", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(version.Info())
@@ -141,7 +144,6 @@ func buildRouter(cfg config.Config, primaryVaultClient vault.Client, statusClien
 	r.Get("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP)
 	handlers.RegisterI18nRoutes(r)
 	handlers.RegisterCertRoutes(r, multiVaultClient)
-	handlers.RegisterAdminRoutes(r, settingsPath, cfg.Env, vaultRegistry, statusClients, multiVaultClient, cfg.TrustProxy)
 
 	return r, nil
 }

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -141,7 +141,7 @@ func buildRouter(cfg config.Config, primaryVaultClient vault.Client, statusClien
 	r.Get("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP)
 	handlers.RegisterI18nRoutes(r)
 	handlers.RegisterCertRoutes(r, multiVaultClient)
-	handlers.RegisterAdminRoutes(r, settingsPath, cfg.Env, vaultRegistry, statusClients, multiVaultClient)
+	handlers.RegisterAdminRoutes(r, settingsPath, cfg.Env, vaultRegistry, statusClients, multiVaultClient, cfg.TrustProxy)
 
 	return r, nil
 }

--- a/app/cmd/server/main_test.go
+++ b/app/cmd/server/main_test.go
@@ -23,7 +23,7 @@ func TestNewStatusHandler_PrimaryConnected(t *testing.T) {
 	primary.On("CheckConnection", mock.Anything).Return(nil)
 
 	cfg := config.Config{Vaults: []config.VaultInstance{}}
-	handler := newStatusHandler(cfg, primary, nil)
+	handler := newStatusHandler(cfg, primary, nil, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	w := httptest.NewRecorder()
@@ -42,7 +42,7 @@ func TestNewStatusHandler_PrimaryDisconnected(t *testing.T) {
 	primary.On("CheckConnection", mock.Anything).Return(errors.New("connection refused"))
 
 	cfg := config.Config{Vaults: []config.VaultInstance{}}
-	handler := newStatusHandler(cfg, primary, nil)
+	handler := newStatusHandler(cfg, primary, nil, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	w := httptest.NewRecorder()
@@ -78,7 +78,7 @@ func TestNewStatusHandler_StatusClients(t *testing.T) {
 		// v3 intentionally missing
 	}
 
-	handler := newStatusHandler(cfg, primary, statusClients)
+	handler := newStatusHandler(cfg, primary, statusClients, true)
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)

--- a/app/cmd/server/status_handler_test.go
+++ b/app/cmd/server/status_handler_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type statusResponse struct {
-	Version        string `json:"version"`
-	VaultConnected bool   `json:"vault_connected"`
-	VaultError     string `json:"vault_error,omitempty"`
-	Vaults         []struct {
+	Version         string `json:"version"`
+	VaultConnected  bool   `json:"vault_connected"`
+	VaultError      string `json:"vault_error,omitempty"`
+	AdminAPIEnabled bool   `json:"admin_api_enabled"`
+	Vaults          []struct {
 		ID          string `json:"id"`
 		DisplayName string `json:"display_name"`
 		Connected   bool   `json:"connected"`
@@ -31,7 +32,7 @@ func TestNewStatusHandler_PrimaryDisconnectedAndMissingClient(t *testing.T) {
 	primary := &vault.MockClient{}
 	primary.On("CheckConnection", mock.Anything).Return(errors.New("primary down"))
 	statusClients := map[string]vault.Client{}
-	h := newStatusHandler(cfg, primary, statusClients)
+	h := newStatusHandler(cfg, primary, statusClients, false)
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -40,6 +41,7 @@ func TestNewStatusHandler_PrimaryDisconnectedAndMissingClient(t *testing.T) {
 	assert.NoError(t, json.NewDecoder(rec.Body).Decode(&payload))
 	assert.False(t, payload.VaultConnected)
 	assert.Equal(t, "vault unavailable", payload.VaultError)
+	assert.False(t, payload.AdminAPIEnabled)
 	assert.Len(t, payload.Vaults, 1)
 	assert.Equal(t, "v1", payload.Vaults[0].ID)
 	assert.Equal(t, "Vault 1", payload.Vaults[0].DisplayName)
@@ -57,7 +59,7 @@ func TestNewStatusHandler_AllConnected(t *testing.T) {
 	client2 := &vault.MockClient{}
 	client2.On("CheckConnection", mock.Anything).Return(nil)
 	statusClients := map[string]vault.Client{"v1": client1, "v2": client2}
-	h := newStatusHandler(cfg, primary, statusClients)
+	h := newStatusHandler(cfg, primary, statusClients, true)
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -66,6 +68,7 @@ func TestNewStatusHandler_AllConnected(t *testing.T) {
 	assert.NoError(t, json.NewDecoder(rec.Body).Decode(&payload))
 	assert.True(t, payload.VaultConnected)
 	assert.Equal(t, "", payload.VaultError)
+	assert.True(t, payload.AdminAPIEnabled)
 	assert.Len(t, payload.Vaults, 2)
 	assert.True(t, payload.Vaults[0].Connected)
 	assert.True(t, payload.Vaults[1].Connected)

--- a/app/internal/handlers/admin.go
+++ b/app/internal/handlers/admin.go
@@ -353,22 +353,23 @@ func isBcryptHash(s string) bool {
 // in favor of the Svelte admin panel that talks to /api/admin/*.
 // Admin remains optional: missing/invalid password skips registration with a clear log.
 // trustProxy should match app.trust_proxy (same as global RateLimit / CSRF).
-func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Environment, vaultRegistry *vault.Registry, vaultStatusClients map[string]vault.Client, cacheClient vault.Client, trustProxy bool) {
+// Returns true when admin routes were registered (bcrypt password present and valid).
+func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Environment, vaultRegistry *vault.Registry, vaultStatusClients map[string]vault.Client, cacheClient vault.Client, trustProxy bool) bool {
 	settingsStore := newAdminSettingsStore(settingsPath, env)
 	settings, err := settingsStore.load()
 	if err != nil {
 		logger.Get().Warn().Err(err).Msg("admin API disabled: settings load failed")
-		return
+		return false
 	}
 
 	password := strings.TrimSpace(settings.Admin.Password)
 	if password == "" {
 		logger.Get().Info().Msg("admin API disabled: admin.password empty")
-		return
+		return false
 	}
 	if !isBcryptHash(password) {
 		logger.Get().Warn().Msg("admin API disabled: admin.password is not a bcrypt hash")
-		return
+		return false
 	}
 
 	secureCookies := env == config.EnvProd
@@ -401,4 +402,5 @@ func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Envi
 		})
 	})
 	logger.Get().Info().Msg("admin API enabled")
+	return true
 }

--- a/app/internal/handlers/admin.go
+++ b/app/internal/handlers/admin.go
@@ -35,10 +35,11 @@ type adminSessionStore struct {
 	sessions      map[string]time.Time
 	sessionTTL    time.Duration
 	secureCookies bool
+	trustProxy    bool
 	limiter       *adminLoginLimiter
 }
 
-func newAdminSessionStore(password string, secureCookies bool) *adminSessionStore {
+func newAdminSessionStore(password string, secureCookies bool, trustProxy bool) *adminSessionStore {
 	ttl := 12 * time.Hour
 	if secureCookies {
 		ttl = 4 * time.Hour
@@ -48,6 +49,7 @@ func newAdminSessionStore(password string, secureCookies bool) *adminSessionStor
 		sessions:      make(map[string]time.Time),
 		sessionTTL:    ttl,
 		secureCookies: secureCookies,
+		trustProxy:    trustProxy,
 		limiter:       newAdminLoginLimiter(5, 3*time.Minute),
 	}
 }
@@ -87,7 +89,7 @@ func (s *adminSessionStore) allowLoginAttempt(r *http.Request) bool {
 	if s.limiter == nil {
 		return true
 	}
-	return s.limiter.allow(time.Now(), httputil.ClientIP(r, s.secureCookies))
+	return s.limiter.allow(time.Now(), httputil.ClientIP(r, s.trustProxy))
 }
 
 func (s *adminSessionStore) pruneSessions(now time.Time) {
@@ -350,7 +352,8 @@ func isBcryptHash(s string) bool {
 // RegisterAdminRoutes wires the JSON admin API. HTMX routes have been removed
 // in favor of the Svelte admin panel that talks to /api/admin/*.
 // Admin remains optional: missing/invalid password skips registration with a clear log.
-func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Environment, vaultRegistry *vault.Registry, vaultStatusClients map[string]vault.Client, cacheClient vault.Client) {
+// trustProxy should match app.trust_proxy (same as global RateLimit / CSRF).
+func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Environment, vaultRegistry *vault.Registry, vaultStatusClients map[string]vault.Client, cacheClient vault.Client, trustProxy bool) {
 	settingsStore := newAdminSettingsStore(settingsPath, env)
 	settings, err := settingsStore.load()
 	if err != nil {
@@ -369,7 +372,7 @@ func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Envi
 	}
 
 	secureCookies := env == config.EnvProd
-	sessions := newAdminSessionStore(password, secureCookies)
+	sessions := newAdminSessionStore(password, secureCookies, trustProxy)
 	store := settingsStore
 	refreshRegistry := func() {
 		if vaultRegistry == nil {

--- a/app/internal/handlers/admin_api_unexported_test.go
+++ b/app/internal/handlers/admin_api_unexported_test.go
@@ -87,7 +87,7 @@ func TestAdminSessionStore_LoginFromJSON(t *testing.T) {
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte("testpassword"), bcrypt.DefaultCost)
 	require.NoError(t, err)
 
-	store := newAdminSessionStore(string(hashedPassword), false)
+	store := newAdminSessionStore(string(hashedPassword), false, false)
 
 	tests := []struct {
 		name          string
@@ -181,7 +181,7 @@ func TestAdminSessionStore_LoginFromJSON_RateLimited(t *testing.T) {
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte("testpassword"), bcrypt.DefaultCost)
 	require.NoError(t, err)
 
-	store := newAdminSessionStore(string(hashedPassword), false)
+	store := newAdminSessionStore(string(hashedPassword), false, false)
 
 	// Make multiple failed attempts to trigger rate limiting
 	body := adminLoginRequest{
@@ -212,7 +212,7 @@ func TestAdminSessionStore_LoginFromJSON_ReplacesExistingSession(t *testing.T) {
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte("testpassword"), bcrypt.DefaultCost)
 	require.NoError(t, err)
 
-	store := newAdminSessionStore(string(hashedPassword), false)
+	store := newAdminSessionStore(string(hashedPassword), false, false)
 
 	// First login
 	body := adminLoginRequest{
@@ -569,7 +569,7 @@ func setupAdminAPIRouter(t *testing.T) (*chi.Mux, *adminSessionStore, *adminSett
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	store := newAdminSettingsStore(settingsPath, config.EnvDev)
-	sessions := newAdminSessionStore(string(hashedPassword), false)
+	sessions := newAdminSessionStore(string(hashedPassword), false, false)
 
 	r := chi.NewRouter()
 	refreshRegistry := func() {}
@@ -687,7 +687,7 @@ func TestAdminSessionStore_LoginFromJSON_RateLimited_EmptyIP(t *testing.T) {
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte("testpassword"), bcrypt.DefaultCost)
 	require.NoError(t, err)
 
-	store := newAdminSessionStore(string(hashedPassword), false)
+	store := newAdminSessionStore(string(hashedPassword), false, false)
 
 	body := adminLoginRequest{
 		Username: "admin",
@@ -958,7 +958,7 @@ func TestRegisterAdminAPIRoutes_VaultDelete_SaveError(t *testing.T) {
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	store := newAdminSettingsStore(settingsPath, config.EnvDev)
-	sessions := newAdminSessionStore(string(hashedPassword), false)
+	sessions := newAdminSessionStore(string(hashedPassword), false, false)
 
 	r := chi.NewRouter()
 	registerAdminAPIRoutes(r, sessions, store, map[string]vault.Client{}, func() {})

--- a/app/internal/handlers/admin_test.go
+++ b/app/internal/handlers/admin_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestAdminSessionStore_NewAdminSessionStore(t *testing.T) {
 	password := "$2a$10$testhashedpassword"
-	store := newAdminSessionStore(password, false)
+	store := newAdminSessionStore(password, false, false)
 
 	assert.NotNil(t, store)
 	assert.Equal(t, password, store.password)
@@ -34,7 +34,7 @@ func TestAdminSessionStore_NewAdminSessionStore(t *testing.T) {
 
 func TestAdminSessionStore_NewAdminSessionStore_SecureCookies(t *testing.T) {
 	password := "$2a$10$testhashedpassword"
-	store := newAdminSessionStore(password, true)
+	store := newAdminSessionStore(password, true, false)
 
 	assert.NotNil(t, store)
 	assert.Equal(t, password, store.password)
@@ -43,7 +43,7 @@ func TestAdminSessionStore_NewAdminSessionStore_SecureCookies(t *testing.T) {
 }
 
 func TestAdminSessionStore_CreateToken(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 
 	token, err := store.createToken()
 	assert.NoError(t, err)
@@ -56,7 +56,7 @@ func TestAdminSessionStore_Verify(t *testing.T) {
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte("testpassword"), bcrypt.DefaultCost)
 	require.NoError(t, err)
 
-	store := newAdminSessionStore(string(hashedPassword), false)
+	store := newAdminSessionStore(string(hashedPassword), false, false)
 
 	tests := []struct {
 		name     string
@@ -111,7 +111,7 @@ func TestAdminSessionStore_Verify(t *testing.T) {
 }
 
 func TestAdminSessionStore_Verify_PlaintextPassword(t *testing.T) {
-	store := newAdminSessionStore("plaintextpassword", false)
+	store := newAdminSessionStore("plaintextpassword", false, false)
 
 	// Should return false for plaintext passwords (not bcrypt)
 	result := store.verify("admin", "plaintextpassword")
@@ -119,7 +119,7 @@ func TestAdminSessionStore_Verify_PlaintextPassword(t *testing.T) {
 }
 
 func TestAdminSessionStore_ClearCookie(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 
 	w := httptest.NewRecorder()
 	store.clearCookie(w)
@@ -139,7 +139,7 @@ func TestAdminSessionStore_ClearCookie(t *testing.T) {
 }
 
 func TestAdminSessionStore_ClearCookie_Secure(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", true)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", true, false)
 
 	w := httptest.NewRecorder()
 	store.clearCookie(w)
@@ -153,7 +153,7 @@ func TestAdminSessionStore_ClearCookie_Secure(t *testing.T) {
 }
 
 func TestAdminSessionStore_IsAuthed(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 
 	// Test without cookie
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -189,7 +189,7 @@ func TestAdminSessionStore_IsAuthed(t *testing.T) {
 }
 
 func TestAdminSessionStore_RequireAuth(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 
 	// Create a test handler that sets a flag when called
 	handlerCalled := false
@@ -440,7 +440,7 @@ func TestShouldFallbackToDirectWrite(t *testing.T) {
 }
 
 func TestAdminSessionStore_PruneSessions(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 
 	now := time.Now()
 	// Add expired sessions
@@ -455,7 +455,7 @@ func TestAdminSessionStore_PruneSessions(t *testing.T) {
 }
 
 func TestAdminSessionStore_PruneSessions_MaxSessions(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 
 	now := time.Now()
 	// Add more sessions than max
@@ -469,7 +469,7 @@ func TestAdminSessionStore_PruneSessions_MaxSessions(t *testing.T) {
 }
 
 func TestAdminSessionStore_AllowLoginAttempt(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 
 	// Should allow initially
 	req := httptest.NewRequest(http.MethodPost, "/login", nil)
@@ -486,15 +486,39 @@ func TestAdminSessionStore_AllowLoginAttempt(t *testing.T) {
 }
 
 func TestAdminSessionStore_AllowLoginAttempt_NilLimiter(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 	store.limiter = nil
 
 	req := httptest.NewRequest(http.MethodPost, "/login", nil)
 	assert.True(t, store.allowLoginAttempt(req))
 }
 
+func TestAdminSessionStore_AllowLoginAttempt_TrustProxy(t *testing.T) {
+	// trustProxy false: forged XFF shares one bucket (RemoteAddr only).
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
+	for i := range 5 {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "192.0.2.10:1234"
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("203.0.113.%d", i+1))
+		assert.True(t, store.allowLoginAttempt(req), "attempt %d should pass under shared key", i)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "192.0.2.10:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.99")
+	assert.False(t, store.allowLoginAttempt(req), "sixth attempt same RemoteAddr must trip limit")
+
+	// trustProxy true: different XFF get separate buckets.
+	storeTrusted := newAdminSessionStore("$2a$10$testhashedpassword", false, true)
+	for i := range 5 {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "192.0.2.10:1234"
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("203.0.113.%d", i+1))
+		assert.True(t, storeTrusted.allowLoginAttempt(req), "distinct XFF %d must have its own bucket", i)
+	}
+}
+
 func TestAdminSessionStore_RequireAuth_ExpiredSession(t *testing.T) {
-	store := newAdminSessionStore("$2a$10$testhashedpassword", false)
+	store := newAdminSessionStore("$2a$10$testhashedpassword", false, false)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -566,7 +590,7 @@ func TestRegisterAdminRoutes(t *testing.T) {
 	vaultStatusClients := make(map[string]vault.Client)
 	cacheClient := &vault.MockClient{}
 
-	RegisterAdminRoutes(r, tmpFile, config.EnvDev, vaultRegistry, vaultStatusClients, cacheClient)
+	RegisterAdminRoutes(r, tmpFile, config.EnvDev, vaultRegistry, vaultStatusClients, cacheClient, false)
 
 	// Verify routes are registered
 	assert.NotNil(t, r)
@@ -593,7 +617,7 @@ func TestRegisterAdminRoutes_EmptyPassword_LoginNotFound(t *testing.T) {
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	r := chi.NewRouter()
-	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, nil)
+	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, nil, false)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/login", strings.NewReader(`{}`))
 	w := httptest.NewRecorder()
@@ -613,7 +637,7 @@ func TestRegisterAdminRoutes_InvalidHash_LoginNotFound(t *testing.T) {
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	r := chi.NewRouter()
-	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, nil)
+	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, nil, false)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/login", strings.NewReader(`{}`))
 	w := httptest.NewRecorder()
@@ -639,7 +663,7 @@ func TestRegisterAdminRoutes_CacheInvalidate(t *testing.T) {
 	cacheClient := &vault.MockClient{}
 	cacheClient.On("InvalidateCache").Return()
 
-	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, cacheClient)
+	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, cacheClient, false)
 
 	// Login to get session
 	loginBody, _ := json.Marshal(map[string]string{"username": "admin", "password": "testpassword"})
@@ -683,7 +707,7 @@ func TestRegisterAdminRoutes_NoCacheClient(t *testing.T) {
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	r := chi.NewRouter()
-	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, nil)
+	RegisterAdminRoutes(r, settingsPath, config.EnvDev, nil, nil, nil, false)
 
 	// Login to get session
 	loginBody, _ := json.Marshal(map[string]string{"username": "admin", "password": "testpassword"})


### PR DESCRIPTION
## Summary
- Pass trustProxy into newAdminSessionStore / RegisterAdminRoutes (same flag as RateLimit/CSRF from plan 011).
- Login rate-limit keys use ClientIP with trustProxy instead of overloading secureCookies.
- Branch targets fix/backend-trusted-proxy (depends on PR #63 for cfg.TrustProxy).

#### Test plan
- [x] cd app && go test ./internal/handlers/ ./cmd/server/ -count=1
- [x] TrustProxy false: forged XFF shares one login bucket
- [x] TrustProxy true: different XFF get separate buckets

Generated with [Devin](https://devin.ai)
