### PR TITLE
fix(metrics): warn when per_certificate metrics are enabled

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -75,7 +75,7 @@ Configuration is loaded from the first file found in this order (see `settingsCa
 - `app.logging.level`, `app.logging.format`, `app.logging.output`, `app.logging.file_path`
 - `cors.allowed_origins`, `cors.allow_credentials`
 - `certificates.expiration_thresholds.critical`, `certificates.expiration_thresholds.warning`
-- `metrics.per_certificate` (default false; high cardinality when true), `metrics.enhanced_metrics`
+- `metrics.per_certificate` (default **false**; prefer aggregate vault|pki|status metrics. When true, emits per-series labels for `certificate_id` and `common_name` — lab only; startup scrape logs a Warn. Per-cert `status` is only valid|revoked|expired, not warning/critical tiers), `metrics.enhanced_metrics`
 - `vaults[]`: list of Vault instances
   - `address`, `token`
   - `pki_mounts` (source of truth; recommended)

--- a/app/internal/metrics/certificate_collector.go
+++ b/app/internal/metrics/certificate_collector.go
@@ -6,25 +6,32 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"vcv/internal/certs"
 	"vcv/internal/config"
+	"vcv/internal/logger"
 	"vcv/internal/vault"
 )
 
 const allLabelValue string = "__all__"
 
+// perCertificateCardinalityWarnThreshold logs an extra warn when inventory size exceeds this while per_certificate is on.
+const perCertificateCardinalityWarnThreshold = 500
+
 var (
+	perCertWarnOnce            sync.Once
+	perCertCountWarnOnce       sync.Once
 	cacheSizeDesc              = prometheus.NewDesc("vcv_cache_size", "Number of items currently cached", nil, nil)
 	certificatesLastFetchDesc  = prometheus.NewDesc("vcv_certificates_last_fetch_timestamp_seconds", "Timestamp of last successful certificates fetch", nil, nil)
 	certificatesTotalDesc      = prometheus.NewDesc("vcv_certificates_total", "Total certificates grouped by status", []string{"vault_id", "pki", "status"}, nil)
 	expiredCountDesc           = prometheus.NewDesc("vcv_certificates_expired_count", "Number of expired certificates", nil, nil)
 	expiringSoonCountDesc      = prometheus.NewDesc("vcv_certificates_expiring_soon_count", "Number of certificates expiring soon within threshold window", []string{"vault_id", "pki", "level"}, nil)
-	expiryTimestampDesc        = prometheus.NewDesc("vcv_certificate_expiry_timestamp_seconds", "Certificate expiration timestamp in seconds since epoch", []string{"certificate_id", "common_name", "status", "vault_id", "pki"}, nil)
-	daysUntilExpiryDesc        = prometheus.NewDesc("vcv_certificate_days_until_expiry", "Days remaining until certificate expiration (negative if expired)", []string{"certificate_id", "common_name", "status", "vault_id", "pki"}, nil)
+	expiryTimestampDesc        = prometheus.NewDesc("vcv_certificate_expiry_timestamp_seconds", "Per-certificate expiration timestamp (high cardinality: certificate_id + common_name labels); status is valid|revoked|expired only", []string{"certificate_id", "common_name", "status", "vault_id", "pki"}, nil)
+	daysUntilExpiryDesc        = prometheus.NewDesc("vcv_certificate_days_until_expiry", "Per-certificate days until expiry (high cardinality: certificate_id + common_name labels); status is valid|revoked|expired only", []string{"certificate_id", "common_name", "status", "vault_id", "pki"}, nil)
 	expiryBucketDesc           = prometheus.NewDesc("vcv_certificates_expiry_bucket", "Number of certificates expiring in time bucket", []string{"vault_id", "pki", "bucket"}, nil)
 	thresholdCriticalDesc      = prometheus.NewDesc("vcv_expiration_threshold_critical_days", "Configured critical expiration threshold in days", nil, nil)
 	thresholdWarningDesc       = prometheus.NewDesc("vcv_expiration_threshold_warning_days", "Configured warning expiration threshold in days", nil, nil)
@@ -416,6 +423,17 @@ func (collector *certificateCollector) emitCertificateAggregationMetrics(ch chan
 func (collector *certificateCollector) emitPerCertificateMetrics(ch chan<- prometheus.Metric, certificates []certs.Certificate, now time.Time) {
 	if !collector.perCertificate {
 		return
+	}
+	perCertWarnOnce.Do(func() {
+		logger.Get().Warn().Msg("metrics.per_certificate is enabled: high Prometheus cardinality (certificate_id, common_name labels)")
+	})
+	if len(certificates) > perCertificateCardinalityWarnThreshold {
+		perCertCountWarnOnce.Do(func() {
+			logger.Get().Warn().
+				Int("certificate_count", len(certificates)).
+				Int("threshold", perCertificateCardinalityWarnThreshold).
+				Msg("metrics.per_certificate inventory exceeds recommended size for per-series labels")
+		})
 	}
 	emitEnhanced := collector.enhancedMetrics
 	for _, certificate := range certificates {

--- a/app/internal/metrics/certificate_collector_test.go
+++ b/app/internal/metrics/certificate_collector_test.go
@@ -120,7 +120,28 @@ func TestCollector_SuccessMetrics(t *testing.T) {
 	mockVault.AssertExpectations(t)
 }
 
+func TestCollector_PerCertificateEnabled_NoPanic(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	certsList := []certs.Certificate{
+		{ID: "pki:c1", CommonName: "one", ExpiresAt: now.Add(48 * time.Hour), CreatedAt: now.Add(-24 * time.Hour)},
+	}
+	mockVault := new(vault.MockClient)
+	mockVault.On("ListCertificates", mock.Anything).Return(certsList, nil)
+	mockVault.On("CheckConnection", mock.Anything).Return(nil)
+	vaultInstances := []config.VaultInstance{{ID: "v1", PKIMounts: []string{"pki"}}}
+	multiClient := vault.NewMultiClient(vaultInstances, map[string]vault.Client{"v1": mockVault}, nil)
+	metricsConfig := config.MetricsConfig{PerCertificate: true, EnhancedMetrics: false}
+	raw := NewCertificateCollectorWithVaults(multiClient, map[string]vault.Client{"v1": mockVault}, config.ExpirationThresholds{Critical: 7, Warning: 30}, metricsConfig, vaultInstances)
+	collector, ok := raw.(*certificateCollector)
+	require.True(t, ok)
+	collector.now = func() time.Time { return now }
+	// Collect twice: sync.Once warn path must not panic on second scrape.
+	assert.Greater(t, testutil.CollectAndCount(collector), 0)
+	assert.Greater(t, testutil.CollectAndCount(collector), 0)
+}
+
 func TestCollector_EnhancedMetrics(t *testing.T) {
+
 	t.Setenv("VCV_METRICS_PER_CERTIFICATE", "false")
 	t.Setenv("VCV_METRICS_ENHANCED", "true")
 	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary
- One-shot Warn when `metrics.per_certificate` is enabled (high Prometheus cardinality).
- Extra one-shot Warn when inventory exceeds 500 certificates with the flag on.
- Clarify per-cert metric HELP strings and README: prefer aggregates; status labels are only valid|revoked|expired.

#### Test plan
- [x] `cd app && go test ./internal/metrics/ -count=1`

Generated with [Devin](https://devin.ai)
