### PR TITLE
fix(admin): expose admin_api_enabled on /api/status

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -121,6 +121,8 @@ vcv is designed for **private networks**. Do not expose the listen port to the p
 | Static SPA `/`, `/admin`, `/assets/*` | Unauthenticated | Admin *API* still requires session |
 | `/api/admin/*` | Session cookie (`vcv_admin_session`) | bcrypt password in settings; disabled if password missing/invalid |
 
+`/api/status` includes `admin_api_enabled` (bool): whether the admin API was registered at process start (valid bcrypt `admin.password`). When false, inventory APIs still run; `/api/ready` stays green (policy B — do not fail readiness solely because admin is off). Startup logs still explain why admin was skipped.
+
 ### What PEMs are
 
 `GET /api/certs/{id}/pem` returns **public** X.509 certificates as stored in Vault PKI. Private keys are never retrieved. Certificate inventories are still sensitive in many organizations.

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -45,7 +45,7 @@ func publicVaultStatusError(err error) string {
 	return "vault unavailable"
 }
 
-func newStatusHandler(cfg config.Config, primaryVaultClient vault.Client, statusClients map[string]vault.Client) http.HandlerFunc {
+func newStatusHandler(cfg config.Config, primaryVaultClient vault.Client, statusClients map[string]vault.Client, adminAPIEnabled bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		type vaultStatusEntry struct {
@@ -55,12 +55,13 @@ func newStatusHandler(cfg config.Config, primaryVaultClient vault.Client, status
 			Error       string `json:"error,omitempty"`
 		}
 		type statusResponse struct {
-			Version        string             `json:"version"`
-			VaultConnected bool               `json:"vault_connected"`
-			VaultError     string             `json:"vault_error,omitempty"`
-			Vaults         []vaultStatusEntry `json:"vaults"`
+			Version         string             `json:"version"`
+			VaultConnected  bool               `json:"vault_connected"`
+			VaultError      string             `json:"vault_error,omitempty"`
+			AdminAPIEnabled bool               `json:"admin_api_enabled"`
+			Vaults          []vaultStatusEntry `json:"vaults"`
 		}
-		response := statusResponse{Version: version.Version, Vaults: make([]vaultStatusEntry, 0, len(cfg.Vaults))}
+		response := statusResponse{Version: version.Version, AdminAPIEnabled: adminAPIEnabled, Vaults: make([]vaultStatusEntry, 0, len(cfg.Vaults))}
 		// Primary connection (historical field) checked in parallel with per-vault checks via helper.
 		primaryClients := map[string]vault.Client{"primary": primaryVaultClient}
 		primaryResults := vault.CheckInstances(ctx, []string{"primary"}, primaryClients, 5*time.Second)
@@ -132,7 +133,9 @@ func buildRouter(cfg config.Config, primaryVaultClient vault.Client, statusClien
 	// Health and readiness probes
 	r.Get("/api/health", handlers.HealthCheck)
 	r.Get("/api/ready", handlers.ReadinessCheck)
-	r.Get("/api/status", newStatusHandler(cfg, primaryVaultClient, statusClients))
+	// Admin is optional; process stays up. Surface enablement on /api/status (not fail-ready).
+	adminAPIEnabled := handlers.RegisterAdminRoutes(r, settingsPath, cfg.Env, vaultRegistry, statusClients, multiVaultClient, cfg.TrustProxy)
+	r.Get("/api/status", newStatusHandler(cfg, primaryVaultClient, statusClients, adminAPIEnabled))
 	r.Get("/api/version", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(version.Info())
@@ -141,7 +144,6 @@ func buildRouter(cfg config.Config, primaryVaultClient vault.Client, statusClien
 	r.Get("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP)
 	handlers.RegisterI18nRoutes(r)
 	handlers.RegisterCertRoutes(r, multiVaultClient)
-	handlers.RegisterAdminRoutes(r, settingsPath, cfg.Env, vaultRegistry, statusClients, multiVaultClient, cfg.TrustProxy)
 
 	return r, nil
 }

--- a/app/cmd/server/main_test.go
+++ b/app/cmd/server/main_test.go
@@ -23,7 +23,7 @@ func TestNewStatusHandler_PrimaryConnected(t *testing.T) {
 	primary.On("CheckConnection", mock.Anything).Return(nil)
 
 	cfg := config.Config{Vaults: []config.VaultInstance{}}
-	handler := newStatusHandler(cfg, primary, nil)
+	handler := newStatusHandler(cfg, primary, nil, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	w := httptest.NewRecorder()
@@ -42,7 +42,7 @@ func TestNewStatusHandler_PrimaryDisconnected(t *testing.T) {
 	primary.On("CheckConnection", mock.Anything).Return(errors.New("connection refused"))
 
 	cfg := config.Config{Vaults: []config.VaultInstance{}}
-	handler := newStatusHandler(cfg, primary, nil)
+	handler := newStatusHandler(cfg, primary, nil, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	w := httptest.NewRecorder()
@@ -78,7 +78,7 @@ func TestNewStatusHandler_StatusClients(t *testing.T) {
 		// v3 intentionally missing
 	}
 
-	handler := newStatusHandler(cfg, primary, statusClients)
+	handler := newStatusHandler(cfg, primary, statusClients, true)
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)

--- a/app/cmd/server/status_handler_test.go
+++ b/app/cmd/server/status_handler_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type statusResponse struct {
-	Version        string `json:"version"`
-	VaultConnected bool   `json:"vault_connected"`
-	VaultError     string `json:"vault_error,omitempty"`
-	Vaults         []struct {
+	Version         string `json:"version"`
+	VaultConnected  bool   `json:"vault_connected"`
+	VaultError      string `json:"vault_error,omitempty"`
+	AdminAPIEnabled bool   `json:"admin_api_enabled"`
+	Vaults          []struct {
 		ID          string `json:"id"`
 		DisplayName string `json:"display_name"`
 		Connected   bool   `json:"connected"`
@@ -31,7 +32,7 @@ func TestNewStatusHandler_PrimaryDisconnectedAndMissingClient(t *testing.T) {
 	primary := &vault.MockClient{}
 	primary.On("CheckConnection", mock.Anything).Return(errors.New("primary down"))
 	statusClients := map[string]vault.Client{}
-	h := newStatusHandler(cfg, primary, statusClients)
+	h := newStatusHandler(cfg, primary, statusClients, false)
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -40,6 +41,7 @@ func TestNewStatusHandler_PrimaryDisconnectedAndMissingClient(t *testing.T) {
 	assert.NoError(t, json.NewDecoder(rec.Body).Decode(&payload))
 	assert.False(t, payload.VaultConnected)
 	assert.Equal(t, "vault unavailable", payload.VaultError)
+	assert.False(t, payload.AdminAPIEnabled)
 	assert.Len(t, payload.Vaults, 1)
 	assert.Equal(t, "v1", payload.Vaults[0].ID)
 	assert.Equal(t, "Vault 1", payload.Vaults[0].DisplayName)
@@ -57,7 +59,7 @@ func TestNewStatusHandler_AllConnected(t *testing.T) {
 	client2 := &vault.MockClient{}
 	client2.On("CheckConnection", mock.Anything).Return(nil)
 	statusClients := map[string]vault.Client{"v1": client1, "v2": client2}
-	h := newStatusHandler(cfg, primary, statusClients)
+	h := newStatusHandler(cfg, primary, statusClients, true)
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -66,6 +68,7 @@ func TestNewStatusHandler_AllConnected(t *testing.T) {
 	assert.NoError(t, json.NewDecoder(rec.Body).Decode(&payload))
 	assert.True(t, payload.VaultConnected)
 	assert.Equal(t, "", payload.VaultError)
+	assert.True(t, payload.AdminAPIEnabled)
 	assert.Len(t, payload.Vaults, 2)
 	assert.True(t, payload.Vaults[0].Connected)
 	assert.True(t, payload.Vaults[1].Connected)

--- a/app/internal/handlers/admin.go
+++ b/app/internal/handlers/admin.go
@@ -353,22 +353,23 @@ func isBcryptHash(s string) bool {
 // in favor of the Svelte admin panel that talks to /api/admin/*.
 // Admin remains optional: missing/invalid password skips registration with a clear log.
 // trustProxy should match app.trust_proxy (same as global RateLimit / CSRF).
-func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Environment, vaultRegistry *vault.Registry, vaultStatusClients map[string]vault.Client, cacheClient vault.Client, trustProxy bool) {
+// Returns true when admin routes were registered (bcrypt password present and valid).
+func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Environment, vaultRegistry *vault.Registry, vaultStatusClients map[string]vault.Client, cacheClient vault.Client, trustProxy bool) bool {
 	settingsStore := newAdminSettingsStore(settingsPath, env)
 	settings, err := settingsStore.load()
 	if err != nil {
 		logger.Get().Warn().Err(err).Msg("admin API disabled: settings load failed")
-		return
+		return false
 	}
 
 	password := strings.TrimSpace(settings.Admin.Password)
 	if password == "" {
 		logger.Get().Info().Msg("admin API disabled: admin.password empty")
-		return
+		return false
 	}
 	if !isBcryptHash(password) {
 		logger.Get().Warn().Msg("admin API disabled: admin.password is not a bcrypt hash")
-		return
+		return false
 	}
 
 	secureCookies := env == config.EnvProd
@@ -401,4 +402,5 @@ func RegisterAdminRoutes(router chi.Router, settingsPath string, env config.Envi
 		})
 	})
 	logger.Get().Info().Msg("admin API enabled")
+	return true
 }


### PR DESCRIPTION
## Summary
- Policy B: process stays up when admin is off; `/api/ready` unchanged.
- `RegisterAdminRoutes` returns whether admin was registered.
- Public `/api/status` adds non-sensitive `admin_api_enabled` for ops visibility (with plan 012 logs).
- Depends on PR #64 (admin register logging base).

#### Test plan
- [x] `cd app && go test ./internal/handlers/ ./cmd/server/ -count=1`

Generated with [Devin](https://devin.ai)
