### PR TITLE
fix(backend): enforce mount allowlist on GetIntermediateCA

### DIFF
--- a/app/internal/vault/real.go
+++ b/app/internal/vault/real.go
@@ -556,6 +556,9 @@ func (c *realClient) GetIntermediateCA(ctx context.Context, mount string) (certs
 	if mount == "" {
 		return certs.DetailedCertificate{}, fmt.Errorf("mount cannot be empty")
 	}
+	if !slices.Contains(c.mounts, mount) {
+		return certs.DetailedCertificate{}, fmt.Errorf("mount %s is not configured", mount)
+	}
 
 	// Try cache first
 	cacheKey := fmt.Sprintf("%s:ca_%s", cacheVersion, mount)

--- a/app/internal/vault/real_client_test.go
+++ b/app/internal/vault/real_client_test.go
@@ -397,6 +397,17 @@ func TestRealClient_GetIntermediateCA(t *testing.T) {
 	}
 }
 
+func TestRealClient_GetIntermediateCA_UnconfiguredMount(t *testing.T) {
+	certificatePEM := newVaultTestCertificatePEM(t)
+	server := newVaultTestServer(vaultTestServerState{certificatePEM: certificatePEM})
+	defer server.Close()
+	client := newRealClientForTest(t, server.URL, []string{"pki"})
+	_, err := client.GetIntermediateCA(context.Background(), "other")
+	if err == nil {
+		t.Fatalf("expected error for unconfigured mount")
+	}
+}
+
 func TestRealClient_GetIntermediateCA_BadResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/v1/pki/ca/pem" {


### PR DESCRIPTION
## Summary
- `GetIntermediateCA` only rejected an empty mount; unlike `parseMountAndSerial` it never checked the mount against `c.mounts`.
- The unauthenticated `GET /api/certs/{id}/ca` route parses the mount straight from the URL id and passes it through unchecked, so a caller could force a Vault read at any mount name using the app's service token — bypassing the configured PKI mount restriction.
- Added the same `slices.Contains(c.mounts, mount)` guard `parseMountAndSerial` already has.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/vault/... -race` (89 passed)
- [x] New `TestRealClient_GetIntermediateCA_UnconfiguredMount` covers the fix