### PR TITLE
fix(backend): never pair wildcard CORS origin with credentials

### DIFF
--- a/app/internal/middleware/middleware.go
+++ b/app/internal/middleware/middleware.go
@@ -110,8 +110,14 @@ func CORS(config CORSConfig) func(http.Handler) http.Handler {
 				return
 			}
 			allowed := false
+			wildcard := false
 			for _, o := range config.AllowedOrigins {
-				if o == "*" || o == origin {
+				if o == "*" {
+					allowed = true
+					wildcard = true
+					break
+				}
+				if o == origin {
 					allowed = true
 					break
 				}
@@ -121,7 +127,10 @@ func CORS(config CORSConfig) func(http.Handler) http.Handler {
 				return
 			}
 			w.Header().Set("Access-Control-Allow-Origin", origin)
-			if config.AllowCredentials {
+			// Credentialed requests must never be paired with a wildcard origin match:
+			// reflecting any Origin while allowing credentials lets any site read
+			// authenticated responses using the browser's ambient session cookie.
+			if config.AllowCredentials && !wildcard {
 				w.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
 			if r.Method == http.MethodOptions {

--- a/app/internal/middleware/middleware_test.go
+++ b/app/internal/middleware/middleware_test.go
@@ -348,6 +348,47 @@ func TestCORS_Preflight(t *testing.T) {
 	}
 }
 
+func TestCORS_WildcardOrigin_NeverSetsCredentials(t *testing.T) {
+	config := middleware.DefaultCORSConfig()
+	config.AllowedOrigins = []string{"*"}
+	config.AllowCredentials = true
+	handler := middleware.CORS(config)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Origin") != "https://evil.example.com" {
+		t.Errorf("expected Access-Control-Allow-Origin to reflect origin, got %q", rec.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if rec.Header().Get("Access-Control-Allow-Credentials") != "" {
+		t.Error("expected no Access-Control-Allow-Credentials header when origin matched via wildcard")
+	}
+}
+
+func TestCORS_ExplicitOrigin_AllowsCredentials(t *testing.T) {
+	config := middleware.DefaultCORSConfig()
+	config.AllowedOrigins = []string{"https://app.example.com"}
+	config.AllowCredentials = true
+	handler := middleware.CORS(config)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Access-Control-Allow-Credentials") != "true" {
+		t.Errorf("expected Access-Control-Allow-Credentials=true for explicitly allowed origin, got %q", rec.Header().Get("Access-Control-Allow-Credentials"))
+	}
+}
+
 func TestRateLimit_BlocksAfterThreshold_PerIP(t *testing.T) {
 	config := middleware.DefaultRateLimitConfig()
 	config.MaxRequests = 2


### PR DESCRIPTION
## Summary
- `CORS()` set `Access-Control-Allow-Credentials: true` whenever `AllowCredentials` was configured, even when the request's Origin matched only via a `"*"` entry in `AllowedOrigins` (reflected, not literal).
- The admin CORS field is free-text with no guard against entering `*`, and `AllowCredentials` is never exposed for editing via the admin API — it's stuck at whatever the prod default (`true`) or settings file holds.
- Combined, an operator widening origins to `*` reproduces a config where any third-party site can read authenticated responses (e.g. `/api/admin/settings`) using an admin's session cookie via a credentialed cross-origin GET.
- Fix: only set the credentials header when the origin matched an explicit entry, never a wildcard.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/middleware/... -race` (53 passed)
- [x] New tests: wildcard match never sets credentials header; explicit-origin match still does