### PR TITLE
ci(web): add frontend type-check and test job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,3 +83,36 @@ jobs:
             exit 1
           fi
         working-directory: app
+
+  web:
+    name: Web check & test
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: app/web/frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: app/web/frontend
+
+      - name: Type-check
+        run: pnpm check
+        working-directory: app/web/frontend
+
+      - name: Test
+        run: pnpm test
+        working-directory: app/web/frontend


### PR DESCRIPTION
## Summary
- CI (`go.yml`) only ever gated on the Go half of the stack: build, `-race` tests, coverage threshold, golangci-lint.
- `release.yml` sets up pnpm/Node but only to run `pnpm build` for goreleaser — no `pnpm check` or `pnpm test` anywhere in CI.
- 15 existing `*.test.ts` files (100 tests) never ran automatically; svelte-check/tsc likewise never gated a PR.
- Adds a `web` job reusing the pnpm/Node setup already proven in `release.yml`, running `pnpm check` (svelte-check + tsc) and `pnpm test` (vitest) from `app/web/frontend`.

## Test plan
- [x] Ran `pnpm install --frozen-lockfile && pnpm check && pnpm test` locally — 0 type errors, 100/100 tests pass
- [x] Validated `go.yml` YAML syntax
- [x] New `web` job mirrors the existing `build` job's structure/permissions