### PR TITLE
fix: repoint lint:css at the real frontend CSS tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "lint": "npm run lint:css && npm run lint:format",
-    "lint:css": "stylelint \"app/web/assets/**/*.css\"",
+    "lint:css": "stylelint \"app/web/frontend/src/**/*.css\"",
     "lint:format": "prettier --check \"**/*.{css,md,json,yml,yaml}\"",
-    "lint:fix": "stylelint \"app/web/assets/**/*.css\" --fix && prettier --write \"**/*.{css,md,json,yml,yaml}\""
+    "lint:fix": "stylelint \"app/web/frontend/src/**/*.css\" --fix && prettier --write \"**/*.{css,md,json,yml,yaml}\""
   },
   "devDependencies": {
     "stylelint": "^17.11.0",


### PR DESCRIPTION
## Summary
- Root `lint:css`/`lint:fix` targeted `app/web/assets/**/*.css`, a directory deleted during the HTMX → Svelte rewrite. Running it hard-errors with `NoFilesFoundError` — dead tooling nobody would catch since it's not wired into CI.
- The real CSS lives under `app/web/frontend/src/` (`app.css`, `styles/vcv/*.css`), and `.stylelintrc.json` already carries Tailwind v4–specific at-rule ignores (`theme`/`apply`/`layer`/`config`/`plugin`/`custom-variant`), confirming this setup was meant for that tree.
- Repointed both scripts' globs.

## Test plan
- [x] `npm run lint:css` — exits 0, lints the real CSS tree cleanly (previously hard-errored)