### PR TITLE
perf(web): precompute CommandPalette search haystack once per cert list

### DIFF
--- a/app/web/frontend/src/lib/components/CommandPalette.svelte
+++ b/app/web/frontend/src/lib/components/CommandPalette.svelte
@@ -36,13 +36,20 @@
     revoked: i18n.t('statusLabelRevoked', 'Revoked'),
   })
 
+  /** Lowercase search haystack per certificate, rebuilt only when the cert list changes (not per keystroke). */
+  const certHaystacks = $derived.by(() =>
+    certs.map((cert) => ({
+      cert,
+      haystack: `${cert.commonName} ${cert.serialNumber} ${cert.sans.join(' ')}`.toLowerCase(),
+    })),
+  )
+
   /** Cert matches when the query appears in its CN, serial, or any SAN. Capped for performance. */
   const matchingCerts = $derived.by(() => {
     const q = query.trim().toLowerCase()
     if (!q) return []
     const out: Certificate[] = []
-    for (const cert of certs) {
-      const haystack = `${cert.commonName} ${cert.serialNumber} ${cert.sans.join(' ')}`.toLowerCase()
+    for (const { cert, haystack } of certHaystacks) {
       if (haystack.includes(q)) out.push(cert)
       if (out.length >= 25) break
     }

--- a/app/web/frontend/src/lib/components/CommandPalette.test.ts
+++ b/app/web/frontend/src/lib/components/CommandPalette.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/svelte'
+import type { Certificate } from '$lib/types'
+
+vi.mock('$lib/stores/i18n.svelte', () => ({
+  getI18n: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+  LANGUAGES: [{ code: 'en', label: 'English' }],
+}))
+
+import CommandPalette from '$lib/components/CommandPalette.svelte'
+
+function cert(overrides: Partial<Certificate> = {}): Certificate {
+  return {
+    id: 'vault1|pki-int:aa:bb',
+    serialNumber: 'aa:bb',
+    commonName: 'web.example.com',
+    sans: ['web.example.com', 'api.example.com'],
+    certType: 'machine',
+    createdAt: '2024-01-01T00:00:00Z',
+    expiresAt: '2999-01-01T00:00:00Z',
+    revoked: false,
+    ...overrides,
+  }
+}
+
+function baseProps(certs: Certificate[]) {
+  return {
+    open: true,
+    onOpenChange: vi.fn(),
+    certs,
+    theme: 'light' as const,
+    onSelectCert: vi.fn(),
+    onToggleStatus: vi.fn(),
+    onToggleTheme: vi.fn(),
+    onSetLang: vi.fn(),
+  }
+}
+
+describe('CommandPalette', () => {
+  it('matches a certificate by common name, serial, or SAN substring', async () => {
+    const certs = [
+      cert({ id: 'a', commonName: 'web.example.com', serialNumber: 'aa:bb', sans: [] }),
+      cert({ id: 'b', commonName: 'other.internal', serialNumber: 'cc:dd', sans: ['san-only.example.com'] }),
+    ]
+    render(CommandPalette, { props: baseProps(certs) })
+
+    const input = screen.getByPlaceholderText('Search certificates or commands…')
+    await fireEvent.input(input, { target: { value: 'san-only' } })
+
+    expect(screen.getByText('other.internal')).toBeInTheDocument()
+    expect(screen.queryByText('web.example.com')).not.toBeInTheDocument()
+  })
+
+  it('re-derives matches when the certificate list changes without a stale haystack', async () => {
+    const initial = [cert({ id: 'a', commonName: 'first.example.com' })]
+    const { rerender } = render(CommandPalette, { props: baseProps(initial) })
+
+    const input = screen.getByPlaceholderText('Search certificates or commands…')
+    await fireEvent.input(input, { target: { value: 'second' } })
+    expect(screen.queryByText('second.example.com')).not.toBeInTheDocument()
+
+    const updated = [cert({ id: 'b', commonName: 'second.example.com' })]
+    await rerender({ ...baseProps(updated) })
+
+    expect(screen.getByText('second.example.com')).toBeInTheDocument()
+  })
+})

--- a/app/web/frontend/vitest.setup.ts
+++ b/app/web/frontend/vitest.setup.ts
@@ -11,3 +11,10 @@ class ResizeObserverMock {
 }
 
 Object.defineProperty(globalThis, 'ResizeObserver', { configurable: true, value: ResizeObserverMock })
+
+// jsdom doesn't implement scrollIntoView; bits-ui's Command component calls it
+// when the highlighted item changes (e.g. CommandPalette filtering as you type).
+// Most test files run in the default 'node' environment, where Element is undefined.
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}


### PR DESCRIPTION
## Summary
- `matchingCerts` in `CommandPalette.svelte` rebuilt a lowercase `${commonName} ${serialNumber} ${sans}` string for every certificate on every keystroke — unlike the main search box, which was already debounced (PR #62).
- On inventories in the hundreds/thousands, every character typed in Cmd/Ctrl-K triggered an O(n) allocation-heavy rebuild.
- Fix: haystacks are now a `$derived` keyed off `certs`, computed once per cert-list change. Per-keystroke work is just a substring scan over the precomputed strings.
- Added `CommandPalette.test.ts` (new file, component had no tests before) covering CN/serial/SAN matching and re-derivation when the cert list changes.
- Bonus: stubbed `Element.prototype.scrollIntoView` in `vitest.setup.ts` (jsdom doesn't implement it; bits-ui's Command component calls it on selection change — these are the first tests to open this component, so the gap was previously unexercised). Guarded for the `node`-environment test files where `Element` doesn't exist.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — 102/102 passed, 0 unhandled errors (previously 3 from the jsdom gap once this component was exercised)
- [x] New tests assert substring matching across CN/serial/SAN and correct re-derivation on cert-list change