### PR TITLE
test(backend): cover ListCertificates cache-hit path

### DIFF
--- a/app/internal/vault/real_client_test.go
+++ b/app/internal/vault/real_client_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -369,6 +370,58 @@ func TestRealClient_ListCertificates_And_Details(t *testing.T) {
 	}
 	client.InvalidateCache()
 	client.Shutdown()
+}
+
+func TestRealClient_ListCertificates_CacheHit(t *testing.T) {
+	certificatePEM := newVaultTestCertificatePEM(t)
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"aa", "bb"}}})
+			return
+		}
+		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs/revoked" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"bb"}}})
+			return
+		}
+		if r.Method == http.MethodGet && (r.URL.Path == "/v1/pki/cert/aa" || r.URL.Path == "/v1/pki/cert/bb") {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"certificate": certificatePEM}})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := newRealClientForTest(t, server.URL, []string{"pki"})
+	ctx := context.Background()
+
+	first, err := client.ListCertificates(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(first) != 2 {
+		t.Fatalf("expected 2 certificates, got %d", len(first))
+	}
+	countAfterFirst := requestCount.Load()
+	if countAfterFirst == 0 {
+		t.Fatalf("expected the first call to reach the vault server")
+	}
+
+	second, err := client.ListCertificates(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(second) != len(first) {
+		t.Fatalf("expected cached result length %d, got %d", len(first), len(second))
+	}
+	if got := requestCount.Load(); got != countAfterFirst {
+		t.Fatalf("expected second ListCertificates call to be served from cache with no new vault requests, got %d additional requests", got-countAfterFirst)
+	}
 }
 
 func TestRealClient_GetIntermediateCA(t *testing.T) {


### PR DESCRIPTION
## Summary
- `ListCertificates`'s cache-hit branch (`internal/vault/real.go`) had 0% test coverage, confirmed via `go tool cover`.
- `GET /api/certs` fans out across every configured vault × mount on every request; the in-memory cache exists specifically to absorb that cost. An undetected regression in the cache-hit branch (e.g. a broken type assertion silently falling through to a full re-fetch) would reintroduce the fan-out cost with no test to catch it.
- Adds `TestRealClient_ListCertificates_CacheHit`, mirroring the existing cache-hit tests for `GetIntermediateCA`/`GetCertificateDetails`: calls `ListCertificates` twice against a request-counting mock Vault server and asserts the second call adds zero requests.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/vault/... -race` (89 passed)