### PR TITLE
test(backend): cover pinned-certificate metrics matching

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
@@ -35,7 +36,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect

--- a/app/internal/metrics/pinned_certificate_metrics_test.go
+++ b/app/internal/metrics/pinned_certificate_metrics_test.go
@@ -1,0 +1,109 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vcv/internal/certs"
+)
+
+// pinnedMetricCertIDs drains ch and returns the certificate_id label value of every
+// emitted metric family produced by emitPinnedCertificateMetrics.
+func pinnedMetricCertIDs(t *testing.T, ch chan prometheus.Metric) []string {
+	t.Helper()
+	close(ch)
+	var ids []string
+	for m := range ch {
+		var pb dto.Metric
+		require.NoError(t, m.Write(&pb))
+		for _, label := range pb.GetLabel() {
+			if label.GetName() == "certificate_id" {
+				ids = append(ids, label.GetValue())
+			}
+		}
+	}
+	return ids
+}
+
+func TestEmitPinnedCertificateMetrics_NoPinnedConfigured(t *testing.T) {
+	collector := &certificateCollector{}
+	ch := make(chan prometheus.Metric, 8)
+	certificates := []certs.Certificate{{
+		ID:         "vault-a|pki:aa",
+		CommonName: "app.example.com",
+		ExpiresAt:  time.Now().Add(30 * 24 * time.Hour),
+	}}
+
+	collector.emitPinnedCertificateMetrics(ch, certificates, time.Now())
+
+	assert.Empty(t, pinnedMetricCertIDs(t, ch))
+}
+
+func TestEmitPinnedCertificateMetrics_ExactCommonNameMatch(t *testing.T) {
+	collector := &certificateCollector{pinnedCertificates: []string{"root.example.com"}}
+	ch := make(chan prometheus.Metric, 8)
+	certificates := []certs.Certificate{
+		{ID: "vault-a|pki:aa", CommonName: "root.example.com", ExpiresAt: time.Now().Add(30 * 24 * time.Hour)},
+		{ID: "vault-a|pki:bb", CommonName: "other.example.com", ExpiresAt: time.Now().Add(30 * 24 * time.Hour)},
+	}
+
+	collector.emitPinnedCertificateMetrics(ch, certificates, time.Now())
+
+	ids := pinnedMetricCertIDs(t, ch)
+	assert.Contains(t, ids, "vault-a|pki:aa")
+	assert.NotContains(t, ids, "vault-a|pki:bb")
+}
+
+func TestEmitPinnedCertificateMetrics_WildcardSANMatch(t *testing.T) {
+	collector := &certificateCollector{pinnedCertificates: []string{"*.internal.example.com"}}
+	ch := make(chan prometheus.Metric, 8)
+	certificates := []certs.Certificate{
+		{
+			ID:         "vault-a|pki:cc",
+			CommonName: "service.example.com",
+			Sans:       []string{"service.example.com", "svc.internal.example.com"},
+			ExpiresAt:  time.Now().Add(30 * 24 * time.Hour),
+		},
+		{
+			ID:         "vault-a|pki:dd",
+			CommonName: "unrelated.example.com",
+			Sans:       []string{"unrelated.example.com"},
+			ExpiresAt:  time.Now().Add(30 * 24 * time.Hour),
+		},
+	}
+
+	collector.emitPinnedCertificateMetrics(ch, certificates, time.Now())
+
+	ids := pinnedMetricCertIDs(t, ch)
+	assert.Contains(t, ids, "vault-a|pki:cc")
+	assert.NotContains(t, ids, "vault-a|pki:dd")
+}
+
+func TestEmitPinnedCertificateMetrics_CaseInsensitive(t *testing.T) {
+	collector := &certificateCollector{pinnedCertificates: []string{"ROOT.EXAMPLE.COM"}}
+	ch := make(chan prometheus.Metric, 8)
+	certificates := []certs.Certificate{
+		{ID: "vault-a|pki:aa", CommonName: "root.example.com", ExpiresAt: time.Now().Add(30 * 24 * time.Hour)},
+	}
+
+	collector.emitPinnedCertificateMetrics(ch, certificates, time.Now())
+
+	assert.Contains(t, pinnedMetricCertIDs(t, ch), "vault-a|pki:aa")
+}
+
+func TestEmitPinnedCertificateMetrics_SkipsZeroExpiry(t *testing.T) {
+	collector := &certificateCollector{pinnedCertificates: []string{"root.example.com"}}
+	ch := make(chan prometheus.Metric, 8)
+	certificates := []certs.Certificate{
+		{ID: "vault-a|pki:aa", CommonName: "root.example.com"}, // ExpiresAt zero value
+	}
+
+	collector.emitPinnedCertificateMetrics(ch, certificates, time.Now())
+
+	assert.Empty(t, pinnedMetricCertIDs(t, ch))
+}


### PR DESCRIPTION
## Summary
- `emitPinnedCertificateMetrics` (wildcard CN/certificate-ID/SAN matching for operator-pinned certs, e.g. pinned root CAs) had 6.1% coverage and zero dedicated tests, confirmed via `go tool cover` and grep.
- This is user-facing security monitoring: a broken pattern match would silently produce zero alerts for a pinned certificate expiring — a false sense of safety with nothing to catch the regression.
- Adds `pinned_certificate_metrics_test.go` covering: exact CommonName match, wildcard SAN match, case-insensitivity, non-matching certs excluded, the no-pinned-configured early return, and the zero-`ExpiresAt` skip. Assertions read the emitted `certificate_id` label via `dto.Metric` for precision rather than just counting metrics.
- `go mod tidy` promotes `github.com/prometheus/client_model` from indirect to direct since the tests use it directly.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/metrics/... -race` (15 passed)