### PR TITLE
chore(web): bump transitive postcss to 8.5.23 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/app/web/frontend/pnpm-lock.yaml
+++ b/app/web/frontend/pnpm-lock.yaml
@@ -823,8 +823,8 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -848,8 +848,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -1790,7 +1790,7 @@ snapshots:
 
   mri@1.2.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   obug@2.1.1: {}
 
@@ -1806,9 +1806,9 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.16:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1997,7 +1997,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.23
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Dependabot alert #14 (high): `postcss` <= 8.5.17, pulled in transitively via `vite`, has a path-traversal in source-map auto-loading (GHSA-r28c-9q8g-f849) that can disclose arbitrary `.map` file contents when the caller processes untrusted CSS.
- Not reachable in this app — postcss only ever processes our own Tailwind source at build time, never user-submitted CSS — but the fix is a free lockfile bump within `vite`'s already-declared `^8.5.16` range.
- `pnpm update postcss` → `postcss@8.5.23` (first patched: 8.5.18).

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — 100/100 passed
- [x] `pnpm build` — succeeds, output unchanged in shape