### PR TITLE
test(backend): guard i18n Messages structs against missing fields

### DIFF
--- a/app/internal/i18n/i18n_coverage_test.go
+++ b/app/internal/i18n/i18n_coverage_test.go
@@ -3,6 +3,7 @@ package i18n
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -149,6 +150,26 @@ func TestMessagesForLanguage_AllLanguages(t *testing.T) {
 			}
 			if msg.StatusLabelValid == "" {
 				t.Errorf("MessagesForLanguage(%v).StatusLabelValid is empty", lang)
+			}
+		})
+	}
+}
+
+// TestMessages_AllFieldsPopulated guards against a field omitted from one
+// language's struct literal: Go silently zero-values a missing keyed field
+// to "", so a typo or forgotten entry ships a blank UI string with no
+// compiler error. Every field on every language must be non-empty.
+func TestMessages_AllFieldsPopulated(t *testing.T) {
+	languages := []Language{LanguageEnglish, LanguageFrench, LanguageSpanish, LanguageGerman, LanguageItalian}
+	messagesType := reflect.TypeFor[Messages]()
+	for _, lang := range languages {
+		t.Run(string(lang), func(t *testing.T) {
+			value := reflect.ValueOf(MessagesForLanguage(lang))
+			for i := 0; i < value.NumField(); i++ {
+				fieldName := messagesType.Field(i).Name
+				if value.Field(i).String() == "" {
+					t.Errorf("Messages.%s is empty for language %v", fieldName, lang)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `Messages` has 195 `json`-tagged fields and 5 full struct literals (one per language). Go allows partial keyed struct literals — a field omitted from one language's literal silently zero-values to `""` with no compiler error.
- The existing `TestMessagesForLanguage_AllLanguages` only spot-checked 3 of 195 fields per language.
- Adds `TestMessages_AllFieldsPopulated`, a reflection-based test asserting every field is non-empty across all 5 languages (en/fr/es/de/it). All currently pass — this closes the gap going forward, not fixing an existing bug.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/i18n/... -race` (59 passed)