### PR TITLE
chore: add go-lint-full make target matching CI's golangci-lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,9 @@ make dev
 # Lint (go fmt + go vet)
 make go-lint
 
+# Full lint (golangci-lint, same checks/version as CI) - slower, run before pushing
+make go-lint-full
+
 # Go unit tests offline (no Vault), with coverage
 make test-offline
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 VCV_VERSION ?= dev-$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 VCV_TAG ?= latest
 
-.PHONY: help web-install web-dev web-build web-check web-test web-test-coverage dev docker-build test-offline test-dev go-update go-lint go-coverage
+.PHONY: help web-install web-dev web-build web-check web-test web-test-coverage dev docker-build test-offline test-dev go-update go-lint go-lint-full go-coverage
 
 help:
 	@printf '%s\n' \
@@ -20,6 +20,7 @@ help:
 		'  test-dev           Run Go tests against the development stack with coverage' \
 		'  go-update          Update Go dependencies' \
 		'  go-lint            Run go fmt and go vet' \
+		'  go-lint-full       Run golangci-lint (same checks and version as CI)' \
 		'  go-coverage        Run Go unit tests with coverage' \
 		'' \
 		'Variables:' \
@@ -68,6 +69,10 @@ go-update:
 
 go-lint:
 	cd app && go fmt ./... && go vet ./...
+
+# Pinned to the same version as .github/workflows/go.yml; bump both together.
+go-lint-full:
+	cd app && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=3m
 
 go-coverage:
 	cd app && go test ./... -count=1 -coverprofile=coverage.out -covermode=atomic 2>&1 && go tool cover -func=coverage.out


### PR DESCRIPTION
## Summary
- `make go-lint` only ran `go fmt` + `go vet`. CI (`.github/workflows/go.yml`) actually gates on `golangci-lint v2.12.2`, which enables `errcheck`, `staticcheck`, `unused`, `gocritic`, `unconvert`, `bodyclose`, `ineffassign` — none of which `go vet`/`go fmt` catch.
- A contributor running `make go-lint` before pushing (as `AGENTS.md` recommends) reasonably believed they'd linted cleanly, then hit CI failures with no local command reproducing them.
- Adds `go-lint-full`, running golangci-lint pinned to the exact CI version via `go run` (no separate install required). Comment ties it to `.github/workflows/go.yml`'s pin so both get bumped together.
- Documented next to `make go-lint` in `AGENTS.md`.

## Test plan
- [x] `make go-lint-full` — "0 issues" (repo already golangci-lint-clean)
- [x] `go build ./...` still succeeds