### PR TITLE
chore: track Go and frontend dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/app/web/frontend"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` only had a `github-actions` ecosystem block — Go module (`app/go.mod`) and frontend (`app/web/frontend`, pnpm lockfile) dependency drift, including security patches, was invisible until someone manually ran `make go-update` or hand-bumped `package.json`.
- Adds `gomod` (directory `/app`) and `npm` (directory `/app/web/frontend`) blocks — Dependabot's `npm` ecosystem auto-detects and supports `pnpm-lock.yaml`. Same weekly cadence as the existing block.

## Test plan
- [x] Validated YAML syntax