### PR TITLE
chore: pause Dependabot on typescript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
     directory: "/app/web/frontend"
     schedule:
       interval: "weekly"
+    ignore:
+      # TS 7.0 ships no stable programmatic compiler API; svelte-check crashes
+      # on startup under it (upstream: sveltejs/language-tools#3063, no fix as
+      # of 2026-07). Revisit once svelte-check or TS 7.1's API lands. See PR #90.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- #90 (`typescript` 6.0.3 → 7.0.2) is held: TS 7.0 ships no stable programmatic compiler API by design (Microsoft's own migration docs say a stable API targets 7.1). `svelte-check` crashes on startup under it — verified locally against both the pinned 4.7.2 and latest 4.7.3, `TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`. Tracked upstream at [sveltejs/language-tools#3063](https://github.com/sveltejs/language-tools/issues/3063), open, no fix as of 2026-07.
- Adds a Dependabot `ignore` rule for `typescript` major-version updates on the frontend `npm` ecosystem entry, so it stops reopening the same blocked bump every cycle. Minor/patch `typescript` updates still flow normally.

## Test plan
- [x] Validated `.github/dependabot.yml` YAML syntax