### PR TITLE
test(web): App.svelte characterization tests + finish filter-bar extraction

### DIFF
--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -4,15 +4,14 @@
   import ShieldCheck from '@lucide/svelte/icons/shield-check'
   import Moon from '@lucide/svelte/icons/moon'
   import RefreshCw from '@lucide/svelte/icons/refresh-cw'
-  import Search from '@lucide/svelte/icons/search'
   import Sun from '@lucide/svelte/icons/sun'
   import { Toaster } from '$lib/components/ui/sonner'
   import * as Select from '$lib/components/ui/select'
   import CertDetailModal from '$lib/components/CertDetailModal.svelte'
-  import CertTypeSelect from '$lib/components/CertTypeSelect.svelte'
   import VaultStatusPill from '$lib/components/VaultStatusPill.svelte'
   import ActiveFilters from '$lib/components/ActiveFilters.svelte'
   import ErrorBanner from '$lib/components/ErrorBanner.svelte'
+  import FilterBar from '$lib/components/FilterBar.svelte'
   import MountSelectorDialog from '$lib/components/MountSelectorDialog.svelte'
   import StatusOverview from '$lib/components/StatusOverview.svelte'
   import CertTable from '$lib/components/CertTable.svelte'
@@ -475,43 +474,21 @@
       </div>
     </div>
 
-    <div id="vcv-filter-bar" class="vcv-filter-bar">
-      <div class="vcv-filter-bar-inner">
-        <div class="vcv-filter-palette">
-          <div class="vcv-palette-item">
-            <span class="vcv-palette-label">{i18n.t('filterChipSources', 'Sources')}</span>
-            <button type="button" class="vcv-mount-filter" onclick={() => (mountModalOpen = true)}>
-              {#if mountFilter === null || mountFilter.length === allMounts.length}
-                {i18n.t('sourcesButtonAll', 'All mounts ({total})', { total: allMounts.length })}
-              {:else}
-                {i18n.t('sourcesButtonPartial', '{selected} / {total} mounts', {
-                  selected: mountFilter.length,
-                  total: allMounts.length,
-                })}
-              {/if}
-            </button>
-          </div>
-          <span class="vcv-palette-separator" aria-hidden="true"></span>
-          <div class="vcv-palette-item">
-            <span class="vcv-palette-label">{i18n.t('filterChipCertType', 'Type')}</span>
-            <CertTypeSelect value={certTypeFilter} onChange={(next) => { certTypeFilter = next; pageIndex = 0 }} />
-          </div>
-        </div>
-        <div class="vcv-search-wrapper">
-          <Search class="vcv-search-icon h-[18px] w-[18px]" aria-hidden="true" />
-          <input
-            id="vcv-search"
-            class="vcv-input vcv-input-search"
-            type="search"
-            aria-label={i18n.t('searchLabel', 'Search certificates')}
-            placeholder={i18n.t('searchPlaceholder', 'Search certificates, serials, SANs…')}
-            bind:value={search}
-            oninput={() => (pageIndex = 0)}
-          />
-          <kbd class="vcv-search-shortcut" aria-label={i18n.t('searchShortcutHint', 'Press / to focus search')}>/</kbd>
-        </div>
-      </div>
-    </div>
+    <FilterBar
+      {search}
+      {certTypeFilter}
+      {mountFilter}
+      allMountsCount={allMounts.length}
+      onSearchInput={(value) => {
+        search = value
+        pageIndex = 0
+      }}
+      onCertTypeChange={(next) => {
+        certTypeFilter = next
+        pageIndex = 0
+      }}
+      onOpenMountModal={() => (mountModalOpen = true)}
+    />
 
     <ActiveFilters
       {search}

--- a/app/web/frontend/src/App.test.ts
+++ b/app/web/frontend/src/App.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/svelte'
+import type { Certificate, CertificatesEnvelope, I18nResponse, PublicConfigResponse, StatusResponse } from '$lib/types'
+
+const { listCertificates, config, status, i18n } = vi.hoisted(() => ({
+  listCertificates: vi.fn(),
+  config: vi.fn(),
+  status: vi.fn(),
+  i18n: vi.fn(),
+}))
+
+vi.mock('$lib/api', () => ({
+  api: { listCertificates, config, status, i18n },
+  ApiError: class ApiError extends Error {},
+}))
+
+import App from './App.svelte'
+
+function cert(overrides: Partial<Certificate> = {}): Certificate {
+  return {
+    id: 'vault1|pki:aa',
+    serialNumber: 'aa',
+    commonName: 'web.example.com',
+    sans: [],
+    certType: 'machine',
+    createdAt: '2024-01-01T00:00:00Z',
+    expiresAt: '2999-01-01T00:00:00Z',
+    revoked: false,
+    ...overrides,
+  }
+}
+
+function mockOk(certificates: Certificate[]): void {
+  listCertificates.mockResolvedValue({ certificates, errors: [] } satisfies CertificatesEnvelope)
+  config.mockResolvedValue({
+    expirationThresholds: { critical: 7, warning: 30 },
+  } satisfies PublicConfigResponse)
+  status.mockResolvedValue({
+    version: '1.9',
+    vault_connected: true,
+    vaults: [],
+  } satisfies StatusResponse)
+  i18n.mockResolvedValue({ language: 'en', messages: {} } satisfies I18nResponse)
+}
+
+beforeEach(() => {
+  listCertificates.mockReset()
+  config.mockReset()
+  status.mockReset()
+  i18n.mockReset()
+  window.history.replaceState(null, '', '/')
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('App', () => {
+  it('loads certificates on mount and renders them (desktop table + mobile list both mount in jsdom)', async () => {
+    mockOk([cert({ id: 'a', commonName: 'web.example.com' }), cert({ id: 'b', commonName: 'api.example.com' })])
+
+    render(App)
+
+    expect(await screen.findAllByText('web.example.com')).toHaveLength(2)
+    expect(screen.getAllByText('api.example.com')).toHaveLength(2)
+    expect(listCertificates).toHaveBeenCalledTimes(1)
+  })
+
+  it('debounces search and updates the result count only after the timer fires', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    mockOk([cert({ id: 'a', commonName: 'web.example.com' }), cert({ id: 'b', commonName: 'other.internal' })])
+
+    render(App)
+    await vi.waitFor(() => expect(listCertificates).toHaveBeenCalledTimes(1))
+
+    const searchInput = screen.getByLabelText('Search certificates') as HTMLInputElement
+    await fireEvent.input(searchInput, { target: { value: 'web' } })
+
+    // Immediately after typing, filtering hasn't happened yet (still debounced).
+    expect(screen.getByText('2 certificates')).toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(screen.getByText('1 certificates')).toBeInTheDocument()
+  })
+
+  it('restores filter/sort/page state from the URL on mount', async () => {
+    window.history.replaceState(null, '', '/?q=web&status=critical&sort=commonName&dir=desc')
+    mockOk([cert({ id: 'a', commonName: 'web.example.com' })])
+
+    render(App)
+    await vi.waitFor(() => expect(listCertificates).toHaveBeenCalledTimes(1))
+
+    const searchInput = screen.getByLabelText('Search certificates') as HTMLInputElement
+    expect(searchInput.value).toBe('web')
+  })
+
+  it('writes filter state back to the URL after the debounce, once hydrated', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    mockOk([cert({ id: 'a', commonName: 'web.example.com' })])
+
+    render(App)
+    await vi.waitFor(() => expect(listCertificates).toHaveBeenCalledTimes(1))
+
+    const searchInput = screen.getByLabelText('Search certificates') as HTMLInputElement
+    await fireEvent.input(searchInput, { target: { value: 'web' } })
+
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(window.location.search).toContain('q=web')
+  })
+})

--- a/app/web/frontend/src/lib/components/FilterBar.svelte
+++ b/app/web/frontend/src/lib/components/FilterBar.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import Search from '@lucide/svelte/icons/search'
+  import CertTypeSelect from '$lib/components/CertTypeSelect.svelte'
+  import { getI18n } from '$lib/stores/i18n.svelte'
+  import type { CertTypeFilter } from '$lib/utils/cert-filter'
+
+  interface Props {
+    search: string
+    certTypeFilter: CertTypeFilter
+    mountFilter: string[] | null
+    allMountsCount: number
+    onSearchInput: (value: string) => void
+    onCertTypeChange: (value: CertTypeFilter) => void
+    onOpenMountModal: () => void
+  }
+
+  const { search, certTypeFilter, mountFilter, allMountsCount, onSearchInput, onCertTypeChange, onOpenMountModal }: Props =
+    $props()
+  const i18n = getI18n()
+</script>
+
+<div id="vcv-filter-bar" class="vcv-filter-bar">
+  <div class="vcv-filter-bar-inner">
+    <div class="vcv-filter-palette">
+      <div class="vcv-palette-item">
+        <span class="vcv-palette-label">{i18n.t('filterChipSources', 'Sources')}</span>
+        <button type="button" class="vcv-mount-filter" onclick={onOpenMountModal}>
+          {#if mountFilter === null || mountFilter.length === allMountsCount}
+            {i18n.t('sourcesButtonAll', 'All mounts ({total})', { total: allMountsCount })}
+          {:else}
+            {i18n.t('sourcesButtonPartial', '{selected} / {total} mounts', {
+              selected: mountFilter.length,
+              total: allMountsCount,
+            })}
+          {/if}
+        </button>
+      </div>
+      <span class="vcv-palette-separator" aria-hidden="true"></span>
+      <div class="vcv-palette-item">
+        <span class="vcv-palette-label">{i18n.t('filterChipCertType', 'Type')}</span>
+        <CertTypeSelect value={certTypeFilter} onChange={onCertTypeChange} />
+      </div>
+    </div>
+    <div class="vcv-search-wrapper">
+      <Search class="vcv-search-icon h-[18px] w-[18px]" aria-hidden="true" />
+      <input
+        id="vcv-search"
+        class="vcv-input vcv-input-search"
+        type="search"
+        aria-label={i18n.t('searchLabel', 'Search certificates')}
+        placeholder={i18n.t('searchPlaceholder', 'Search certificates, serials, SANs…')}
+        value={search}
+        oninput={(event) => onSearchInput((event.target as HTMLInputElement).value)}
+      />
+      <kbd class="vcv-search-shortcut" aria-label={i18n.t('searchShortcutHint', 'Press / to focus search')}>/</kbd>
+    </div>
+  </div>
+</div>

--- a/app/web/frontend/vitest.setup.ts
+++ b/app/web/frontend/vitest.setup.ts
@@ -18,3 +18,20 @@ Object.defineProperty(globalThis, 'ResizeObserver', { configurable: true, value:
 if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {}
 }
+
+// jsdom doesn't implement matchMedia; the theme store reads it to detect the
+// OS color scheme on mount. Most test files run in the default 'node'
+// environment, where window is undefined.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList
+}


### PR DESCRIPTION
## Summary

Two commits, one plan step:

1. **Characterization tests** — `App.svelte` is the highest-churn frontend file (30+ commits: debounced search, URL-state sync, expiry-notify tiers, refresh race guard) and had zero coverage. Adds `App.test.ts` mocking `$lib/api` and asserting: initial load populates both desktop table and mobile list, search debounce only updates the result count after the timer, URL state hydrates filters on mount, and filter changes write back to the URL after their debounce. Also stubs `window.matchMedia` in `vitest.setup.ts` (jsdom gap, first test to instantiate a real theme store).
2. **Extract `FilterBar.svelte`** — plan `005-extract-app-shell` (done) landed `CertTable`/`CertMobileList`/`PaginationBar` but left step 5 (filter bar) undone; `App.svelte` stayed at 693 lines against the plan's own ~450-line target. Moves the search input, cert-type select, and mount-filter trigger out, following the existing value+callback prop convention (`CertTypeSelect`, `MountSelectorDialog` — no `bind:`, i18n via `getI18n()` context). `App.svelte`: 693 → 670 lines.

The characterization tests landed first and pass unchanged after the extraction — that's the behavior-preservation proof plan 005 asked for.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — 106/106 passed (17 files)
- [x] `pnpm build` — succeeds
- [ ] Live visual smoke (`make web-dev` against a real backend) — not run; the automated suite already exercises search/URL/debounce end-to-end through the extracted component, and standing up the dev stack was disproportionate for this change. Flagging in case a reviewer wants to eyeball it.