### PR TITLE
feat: webhook alerting for certificate expiry

### DIFF
--- a/ALERTING.md
+++ b/ALERTING.md
@@ -1,4 +1,42 @@
-# VaultCertsViewer alerting with Prometheus and Alertmanager
+# VaultCertsViewer alerting
+
+Two independent alerting paths: a built-in webhook for teams without a
+Prometheus/Alertmanager stack, and Prometheus metrics + Alertmanager rules
+for teams that already have one. Use either, or both.
+
+## Built-in webhook notifications
+
+Set a webhook URL (Settings → Notifications in the admin panel, or
+`notifications.webhook_url` in `settings.json`) and the server POSTs a JSON
+alert whenever a certificate crosses the warning or critical expiration
+threshold — no browser tab needs to be open.
+
+```json
+{
+  "text": "3 certificate(s) expiring within 7 days or fewer (critical)",
+  "tier": "critical",
+  "warning_count": 5,
+  "critical_count": 3,
+  "thresholds": { "warning_days": 30, "critical_days": 7 }
+}
+```
+
+The top-level `text` field renders as-is in Slack, Discord, and Mattermost
+incoming webhooks with no extra configuration; the structured fields are
+there for anything else (n8n, a custom script, a second Slack block).
+
+- **Cadence**: checked once on startup, then every 15 minutes.
+- **Escalate-only**: one alert per tier (warning, then critical) — it doesn't
+  repeat every 15 minutes at the same tier. Once expiry clears back below the
+  warning threshold, the next crossing alerts again from the top.
+- **Failure handling**: a failed delivery (timeout, non-2xx, DNS failure) is
+  logged and retried on the next check; it never affects the rest of the app.
+- **Treat the URL as a secret**: many providers (Slack, Discord) embed an
+  auth token in the webhook path. The admin API masks it the same way it
+  masks Vault tokens — blank on every read, and a blank/masked value on save
+  preserves the stored URL rather than clearing it.
+
+## Prometheus and Alertmanager
 
 If you are using AlertManager, you can create alerts based on these metrics.
 

--- a/app/README.md
+++ b/app/README.md
@@ -76,6 +76,7 @@ Configuration is loaded from the first file found in this order (see `settingsCa
 - `cors.allowed_origins`, `cors.allow_credentials`
 - `certificates.expiration_thresholds.critical`, `certificates.expiration_thresholds.warning`
 - `metrics.per_certificate` (default **false**; prefer aggregate vault|pki|status metrics. When true, emits per-series labels for `certificate_id` and `common_name` — lab only; startup scrape logs a Warn. Per-cert `status` is only valid|revoked|expired, not warning/critical tiers), `metrics.enhanced_metrics`
+- `notifications.webhook_url` (optional; empty disables). POSTs a JSON alert when a certificate crosses the warning or critical threshold — see `ALERTING.md`.
 - `vaults[]`: list of Vault instances
   - `address`, `token`
   - `pki_mounts` (source of truth; recommended)
@@ -142,6 +143,16 @@ vcv is designed for **private networks**. Do not expose the listen port to the p
 
 5. Admin panel: set `admin.password` to a bcrypt hash to enable; omit the field (or use an invalid hash) to disable. Sessions are in-process memory (sticky sessions or external store needed for horizontal scale).
 6. TLS to Vault: `tls_insecure: false` plus CA material in production.
+
+### Outbound webhook notifications
+
+When `notifications.webhook_url` is configured, this is the app's only
+outbound network call (everything else is inbound HTTP or reads from
+Vault). The URL is operator-configured, not derived from any request input,
+so it carries the same trust level as a Vault address or CORS origin — no
+additional allowlisting beyond requiring an absolute `http`/`https` URL.
+The admin API masks it like a Vault token (see `ALERTING.md`) since
+provider-issued webhook URLs commonly embed an auth token in the path.
 
 ### App-layer controls already present
 

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"vcv/internal/handlers"
 	"vcv/internal/logger"
 	"vcv/internal/middleware"
+	"vcv/internal/notify"
 	"vcv/internal/vault"
 	"vcv/internal/version"
 	"vcv/web"
@@ -31,6 +32,7 @@ const serverReadHeaderTimeout time.Duration = 5 * time.Second
 const serverMaxHeaderBytes int = 1 << 20
 const routerMaxBodyBytes int64 = 1 << 20
 const routerRateLimitMaxRequests int = 300
+const notifyCheckInterval time.Duration = 15 * time.Minute
 const routerRateLimitWindow time.Duration = 1 * time.Minute
 
 // publicVaultStatusError maps internal vault connection errors to stable,
@@ -243,11 +245,30 @@ func main() {
 		}
 	}()
 
+	notifier := notify.New(multiVaultClient, config.Load)
+	notifyCtx, notifyCancel := context.WithCancel(context.Background())
+	go func() {
+		// Check once shortly after startup so an already-crossed threshold
+		// notifies promptly, then on a fixed interval.
+		notifier.Check(notifyCtx)
+		ticker := time.NewTicker(notifyCheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				notifier.Check(notifyCtx)
+			case <-notifyCtx.Done():
+				return
+			}
+		}
+	}()
+
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 
 	log.Info().Msg("Shutting down server...")
+	notifyCancel()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/app/internal/certs/expiry.go
+++ b/app/internal/certs/expiry.go
@@ -1,0 +1,35 @@
+package certs
+
+import (
+	"math"
+	"time"
+)
+
+// CountExpiring counts non-revoked, unexpired certificates whose remaining days
+// until expiry fall within the warning and critical thresholds. A certificate
+// inside the critical window is also counted toward warning when its remaining
+// days are within the warning threshold too - callers get both counts from one
+// pass. warningDays or criticalDays <= 0 disables that threshold.
+func CountExpiring(certificates []Certificate, warningDays, criticalDays int, now time.Time) (warning, critical int) {
+	for _, certificate := range certificates {
+		if certificate.Revoked || certificate.ExpiresAt.IsZero() || certificate.ExpiresAt.Before(now) {
+			continue
+		}
+		daysRemaining := daysUntilExpiry(certificate.ExpiresAt, now)
+		if daysRemaining < 0 {
+			continue
+		}
+		if warningDays > 0 && daysRemaining <= warningDays {
+			warning++
+		}
+		if criticalDays > 0 && daysRemaining <= criticalDays {
+			critical++
+		}
+	}
+	return warning, critical
+}
+
+func daysUntilExpiry(expiresAt, now time.Time) int {
+	diff := expiresAt.Sub(now)
+	return int(math.Ceil(diff.Hours() / 24))
+}

--- a/app/internal/certs/expiry_test.go
+++ b/app/internal/certs/expiry_test.go
@@ -1,0 +1,40 @@
+package certs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountExpiring(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	certs := []Certificate{
+		{ID: "critical", ExpiresAt: now.Add(3 * 24 * time.Hour)},
+		{ID: "warning", ExpiresAt: now.Add(20 * 24 * time.Hour)},
+		{ID: "far-future", ExpiresAt: now.Add(365 * 24 * time.Hour)},
+		{ID: "expired", ExpiresAt: now.Add(-24 * time.Hour)},
+		{ID: "revoked-but-soon", ExpiresAt: now.Add(1 * 24 * time.Hour), Revoked: true},
+		{ID: "no-expiry"},
+	}
+
+	warning, critical := CountExpiring(certs, 30, 7, now)
+	assert.Equal(t, 2, warning) // critical + warning both fall within the 30-day warning window
+	assert.Equal(t, 1, critical)
+}
+
+func TestCountExpiring_DisabledThresholds(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	certs := []Certificate{{ID: "soon", ExpiresAt: now.Add(24 * time.Hour)}}
+
+	warning, critical := CountExpiring(certs, 0, 0, now)
+	assert.Equal(t, 0, warning)
+	assert.Equal(t, 0, critical)
+}
+
+func TestCountExpiring_Empty(t *testing.T) {
+	warning, critical := CountExpiring(nil, 30, 7, time.Now())
+	assert.Equal(t, 0, warning)
+	assert.Equal(t, 0, critical)
+}

--- a/app/internal/config/config.go
+++ b/app/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	AllVaults            []VaultInstance
 	ExpirationThresholds ExpirationThresholds
 	Metrics              MetricsConfig
+	Notifications        NotificationsConfig
 }
 
 // CORSConfig holds CORS-specific configuration.
@@ -69,13 +70,21 @@ type MetricsConfig struct {
 	PinnedCertificates []string `json:"pinned_certificates"`
 }
 
+// NotificationsConfig holds outbound alert delivery configuration.
+type NotificationsConfig struct {
+	// WebhookURL receives a JSON POST when a certificate crosses into the
+	// warning or critical expiration window. Empty disables webhook delivery.
+	WebhookURL string
+}
+
 type SettingsFile struct {
-	App          AppSettings         `json:"app"`
-	Admin        AdminSettings       `json:"admin"`
-	Certificates CertificateSettings `json:"certificates"`
-	Metrics      MetricsSettings     `json:"metrics"`
-	CORS         CORSSettings        `json:"cors"`
-	Vaults       []VaultInstance     `json:"vaults"`
+	App           AppSettings          `json:"app"`
+	Admin         AdminSettings        `json:"admin"`
+	Certificates  CertificateSettings  `json:"certificates"`
+	Metrics       MetricsSettings      `json:"metrics"`
+	CORS          CORSSettings         `json:"cors"`
+	Notifications NotificationSettings `json:"notifications"`
+	Vaults        []VaultInstance      `json:"vaults"`
 }
 
 type AppSettings struct {
@@ -105,6 +114,10 @@ type MetricsSettings struct {
 	PerCertificate     *bool    `json:"per_certificate"`
 	EnhancedMetrics    *bool    `json:"enhanced_metrics"`
 	PinnedCertificates []string `json:"pinned_certificates"`
+}
+
+type NotificationSettings struct {
+	WebhookURL string `json:"webhook_url"`
 }
 
 type AdminSettings struct {
@@ -214,6 +227,7 @@ func buildConfigFromSettings(settings SettingsFile) Config {
 		metrics.PinnedCertificates = settings.Metrics.PinnedCertificates
 	}
 	// Otherwise, keep defaults (PerCertificate: false, EnhancedMetrics: true)
+	notifications := NotificationsConfig{WebhookURL: strings.TrimSpace(settings.Notifications.WebhookURL)}
 	return Config{
 		Env:                  env,
 		Port:                 port,
@@ -227,6 +241,7 @@ func buildConfigFromSettings(settings SettingsFile) Config {
 		Vaults:               []VaultInstance{},
 		ExpirationThresholds: expirations,
 		Metrics:              metrics,
+		Notifications:        notifications,
 	}
 }
 

--- a/app/internal/docs/ADMIN.md
+++ b/app/internal/docs/ADMIN.md
@@ -47,6 +47,19 @@ A comma-separated list of origins permitted to call the JSON API from a
 browser, e.g. `https://app.example.com, https://other.example.com`. Leave
 empty to keep the API same-origin only.
 
+## Notifications
+
+Set a **webhook URL** to get a JSON alert POSTed whenever a certificate
+crosses the warning or critical expiration threshold — no browser tab needs
+to stay open. Checked once at startup, then every 15 minutes; one alert per
+threshold crossed, not a repeat every check. Leave blank to disable.
+
+The URL is treated as a secret (many providers embed an auth token in the
+path) and handled the same way as a vault token: it's never sent back to
+the browser, and leaving the field blank when editing keeps the existing
+URL. See `ALERTING.md` in the repo for the payload shape and a
+Prometheus/Alertmanager alternative.
+
 ## Vaults
 
 Each vault row maps to one HashiCorp Vault or OpenBao instance:

--- a/app/internal/errors/errors.go
+++ b/app/internal/errors/errors.go
@@ -3,9 +3,10 @@ package errors
 import "errors"
 
 var (
-	ErrVaultIDEmpty     = errors.New("vault id is empty")
-	ErrDuplicateVaultID = errors.New("duplicate vault id")
-	ErrInvalidAddress   = errors.New("invalid vault address")
-	ErrInvalidToken     = errors.New("invalid vault token")
-	ErrInvalidThreshold = errors.New("invalid expiration threshold")
+	ErrVaultIDEmpty      = errors.New("vault id is empty")
+	ErrDuplicateVaultID  = errors.New("duplicate vault id")
+	ErrInvalidAddress    = errors.New("invalid vault address")
+	ErrInvalidToken      = errors.New("invalid vault token")
+	ErrInvalidThreshold  = errors.New("invalid expiration threshold")
+	ErrInvalidWebhookURL = errors.New("invalid webhook url")
 )

--- a/app/internal/errors/errors_test.go
+++ b/app/internal/errors/errors_test.go
@@ -19,6 +19,7 @@ func TestErrorVariables(t *testing.T) {
 		{"ErrInvalidAddress", ErrInvalidAddress, "invalid vault address"},
 		{"ErrInvalidToken", ErrInvalidToken, "invalid vault token"},
 		{"ErrInvalidThreshold", ErrInvalidThreshold, "invalid expiration threshold"},
+		{"ErrInvalidWebhookURL", ErrInvalidWebhookURL, "invalid webhook url"},
 	}
 
 	for _, tt := range tests {
@@ -36,6 +37,7 @@ func TestErrorUniqueness(t *testing.T) {
 		ErrInvalidAddress,
 		ErrInvalidToken,
 		ErrInvalidThreshold,
+		ErrInvalidWebhookURL,
 	}
 
 	seen := make(map[string]bool)

--- a/app/internal/handlers/admin.go
+++ b/app/internal/handlers/admin.go
@@ -303,6 +303,13 @@ func shouldFallbackToDirectWrite(err error) bool {
 }
 
 func validateSettings(settings config.SettingsFile) error {
+	if webhookURL := strings.TrimSpace(settings.Notifications.WebhookURL); webhookURL != "" {
+		parsed, err := url.Parse(webhookURL)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+			return vcverrors.ErrInvalidWebhookURL
+		}
+	}
+
 	normalizedVaults := make([]config.VaultInstance, len(settings.Vaults))
 	copy(normalizedVaults, settings.Vaults)
 	seen := make(map[string]struct{})

--- a/app/internal/handlers/admin_api.go
+++ b/app/internal/handlers/admin_api.go
@@ -158,6 +158,7 @@ func registerAdminAPIRoutes(
 				if !errors.Is(saveErr, vcverrors.ErrInvalidAddress) &&
 					!errors.Is(saveErr, vcverrors.ErrInvalidToken) &&
 					!errors.Is(saveErr, vcverrors.ErrInvalidThreshold) &&
+					!errors.Is(saveErr, vcverrors.ErrInvalidWebhookURL) &&
 					!errors.Is(saveErr, vcverrors.ErrVaultIDEmpty) &&
 					!errors.Is(saveErr, vcverrors.ErrDuplicateVaultID) {
 					status = http.StatusInternalServerError

--- a/app/internal/handlers/admin_api.go
+++ b/app/internal/handlers/admin_api.go
@@ -138,7 +138,7 @@ func registerAdminAPIRoutes(
 				return
 			}
 			statuses := computeVaultStatuses(req.Context(), settings.Vaults, vaultStatusClients)
-			writeJSON(w, http.StatusOK, adminSettingsResponse{Settings: maskVaultTokens(settings), VaultStatuses: statuses})
+			writeJSON(w, http.StatusOK, adminSettingsResponse{Settings: maskSecrets(settings), VaultStatuses: statuses})
 		})
 
 		r.Put("/api/admin/settings", func(w http.ResponseWriter, req *http.Request) {
@@ -173,7 +173,7 @@ func registerAdminAPIRoutes(
 				return
 			}
 			statuses := computeVaultStatuses(req.Context(), updated.Vaults, vaultStatusClients)
-			writeJSON(w, http.StatusOK, adminSettingsResponse{Settings: maskVaultTokens(updated), VaultStatuses: statuses})
+			writeJSON(w, http.StatusOK, adminSettingsResponse{Settings: maskSecrets(updated), VaultStatuses: statuses})
 		})
 
 		r.Post("/api/admin/vault", func(w http.ResponseWriter, req *http.Request) {
@@ -241,27 +241,43 @@ func mergeAdminSettings(current, incoming config.SettingsFile) config.SettingsFi
 	merged.Metrics.EnhancedMetrics = incoming.Metrics.EnhancedMetrics
 	merged.Metrics.PinnedCertificates = incoming.Metrics.PinnedCertificates
 	merged.CORS.AllowedOrigins = incoming.CORS.AllowedOrigins
+	merged.Notifications.WebhookURL = mergeSecret(incoming.Notifications.WebhookURL, current.Notifications.WebhookURL)
 	merged.Vaults = mergeVaultTokens(incoming.Vaults, current.Vaults)
 	return merged
 }
 
-// maskVaultTokens returns a copy of settings with every vault's Token blanked
-// so cleartext tokens never reach the browser. Stored tokens are preserved on
-// save by mergeVaultTokens when the incoming Token is empty, so the round-trip
-// still works with masked responses.
-func maskVaultTokens(s config.SettingsFile) config.SettingsFile {
+// mergeSecret returns incoming unless it's blank or a UI mask sentinel, in
+// which case the previously stored value is preserved. Used for any
+// settings field whose GET response must never round-trip a masked value
+// back into storage (webhook URL may carry an auth token in its path, same
+// concern as vault tokens).
+func mergeSecret(incoming, existing string) string {
+	if isBlankOrMaskedSecret(incoming) {
+		return existing
+	}
+	return incoming
+}
+
+// maskSecrets returns a copy of settings with every vault's Token and the
+// webhook URL blanked, so cleartext secrets never reach the browser. Stored
+// values are preserved on save by mergeVaultTokens/mergeSecret when the
+// incoming field is empty, so the round-trip still works with masked
+// responses.
+func maskSecrets(s config.SettingsFile) config.SettingsFile {
 	out := s
 	out.Vaults = make([]config.VaultInstance, len(s.Vaults))
 	for i, v := range s.Vaults {
 		v.Token = ""
 		out.Vaults[i] = v
 	}
+	out.Notifications.WebhookURL = ""
 	return out
 }
 
-// isBlankOrMaskedToken reports whether token is empty or a common UI mask
-// sentinel that must not overwrite a stored Vault token on admin PUT.
-func isBlankOrMaskedToken(token string) bool {
+// isBlankOrMaskedSecret reports whether value is empty or a common UI mask
+// sentinel that must not overwrite a stored secret (vault token, webhook
+// URL) on admin PUT.
+func isBlankOrMaskedSecret(token string) bool {
 	t := strings.TrimSpace(token)
 	if t == "" {
 		return true
@@ -283,7 +299,7 @@ func mergeVaultTokens(incoming, existing []config.VaultInstance) []config.VaultI
 	}
 	merged := make([]config.VaultInstance, 0, len(incoming))
 	for _, v := range incoming {
-		if isBlankOrMaskedToken(v.Token) {
+		if isBlankOrMaskedSecret(v.Token) {
 			lookupKey := v.OriginalID
 			if lookupKey == "" {
 				lookupKey = v.ID

--- a/app/internal/handlers/admin_api_unexported_test.go
+++ b/app/internal/handlers/admin_api_unexported_test.go
@@ -434,18 +434,18 @@ func TestMergeVaultTokens_PreservesEmptyTokens(t *testing.T) {
 }
 
 func TestIsBlankOrMaskedToken(t *testing.T) {
-	assert.True(t, isBlankOrMaskedToken(""))
-	assert.True(t, isBlankOrMaskedToken("   "))
-	assert.True(t, isBlankOrMaskedToken("***"))
-	assert.True(t, isBlankOrMaskedToken("********"))
-	assert.True(t, isBlankOrMaskedToken("••••••••"))
-	assert.True(t, isBlankOrMaskedToken("__MASKED__"))
-	assert.True(t, isBlankOrMaskedToken("[masked]"))
-	assert.True(t, isBlankOrMaskedToken("*****"))
-	assert.False(t, isBlankOrMaskedToken("s.real-vault-token"))
-	assert.False(t, isBlankOrMaskedToken("hvs.real"))
-	assert.False(t, isBlankOrMaskedToken("*"))  // too short to treat as mask
-	assert.False(t, isBlankOrMaskedToken("**")) // too short
+	assert.True(t, isBlankOrMaskedSecret(""))
+	assert.True(t, isBlankOrMaskedSecret("   "))
+	assert.True(t, isBlankOrMaskedSecret("***"))
+	assert.True(t, isBlankOrMaskedSecret("********"))
+	assert.True(t, isBlankOrMaskedSecret("••••••••"))
+	assert.True(t, isBlankOrMaskedSecret("__MASKED__"))
+	assert.True(t, isBlankOrMaskedSecret("[masked]"))
+	assert.True(t, isBlankOrMaskedSecret("*****"))
+	assert.False(t, isBlankOrMaskedSecret("s.real-vault-token"))
+	assert.False(t, isBlankOrMaskedSecret("hvs.real"))
+	assert.False(t, isBlankOrMaskedSecret("*"))  // too short to treat as mask
+	assert.False(t, isBlankOrMaskedSecret("**")) // too short
 }
 
 func TestMergeVaultTokens_PreservesMaskedPlaceholders(t *testing.T) {
@@ -465,6 +465,38 @@ func TestMergeVaultTokens_PreservesMaskedPlaceholders(t *testing.T) {
 	}, existing)
 	require.Len(t, result, 1)
 	assert.Equal(t, "brand-new-token", result[0].Token)
+}
+
+func TestMergeSecret(t *testing.T) {
+	assert.Equal(t, "new-url", mergeSecret("new-url", "old-url"))
+	assert.Equal(t, "old-url", mergeSecret("", "old-url"))
+	for _, masked := range []string{"***", "********", "__MASKED__", "[masked]", "••••••••"} {
+		assert.Equal(t, "old-url", mergeSecret(masked, "old-url"), "mask %q must preserve the stored value", masked)
+	}
+}
+
+func TestMaskSecrets_BlanksWebhookURL(t *testing.T) {
+	settings := config.SettingsFile{
+		Notifications: config.NotificationSettings{WebhookURL: "https://hooks.example.com/services/T000/B000/SECRET"},
+		Vaults:        []config.VaultInstance{{ID: "vault1", Token: "s.real-token"}},
+	}
+
+	masked := maskSecrets(settings)
+
+	assert.Empty(t, masked.Notifications.WebhookURL)
+	assert.Empty(t, masked.Vaults[0].Token)
+}
+
+func TestMergeAdminSettings_WebhookURL(t *testing.T) {
+	current := config.SettingsFile{Notifications: config.NotificationSettings{WebhookURL: "https://hooks.example.com/existing"}}
+
+	// Blank incoming (masked GET response round-tripped unchanged) preserves the stored URL.
+	unchanged := mergeAdminSettings(current, config.SettingsFile{})
+	assert.Equal(t, "https://hooks.example.com/existing", unchanged.Notifications.WebhookURL)
+
+	// A real new URL replaces it.
+	updated := mergeAdminSettings(current, config.SettingsFile{Notifications: config.NotificationSettings{WebhookURL: "https://hooks.example.com/new"}})
+	assert.Equal(t, "https://hooks.example.com/new", updated.Notifications.WebhookURL)
 }
 
 func TestComputeVaultStatuses(t *testing.T) {

--- a/app/internal/handlers/admin_test.go
+++ b/app/internal/handlers/admin_test.go
@@ -379,6 +379,34 @@ func TestValidateSettings(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "empty webhook url is valid (disabled)",
+			settings: config.SettingsFile{
+				Notifications: config.NotificationSettings{WebhookURL: ""},
+			},
+			wantErr: false,
+		},
+		{
+			name: "https webhook url is valid",
+			settings: config.SettingsFile{
+				Notifications: config.NotificationSettings{WebhookURL: "https://hooks.example.com/services/T000/B000/XXXX"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "webhook url missing scheme is invalid",
+			settings: config.SettingsFile{
+				Notifications: config.NotificationSettings{WebhookURL: "hooks.example.com/webhook"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "webhook url with non-http scheme is invalid",
+			settings: config.SettingsFile{
+				Notifications: config.NotificationSettings{WebhookURL: "file:///etc/passwd"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/app/internal/i18n/i18n.go
+++ b/app/internal/i18n/i18n.go
@@ -182,44 +182,48 @@ type Messages struct {
 
 	// Added for the Svelte UI: status labels/descriptions, pagination,
 	// banners, copy actions and admin strings the rewrite previously hardcoded.
-	StatusLabelCritical      string `json:"statusLabelCritical"`
-	StatusLabelWarning       string `json:"statusLabelWarning"`
-	StatusDescValid          string `json:"statusDescValid"`
-	StatusDescWarning        string `json:"statusDescWarning"`
-	StatusDescCritical       string `json:"statusDescCritical"`
-	StatusDescExpired        string `json:"statusDescExpired"`
-	StatusDescRevoked        string `json:"statusDescRevoked"`
-	LabelValidity            string `json:"labelValidity"`
-	LabelCopy                string `json:"labelCopy"`
-	LabelCopied              string `json:"labelCopied"`
-	LabelCopyPEM             string `json:"labelCopyPem"`
-	ButtonDone               string `json:"buttonDone"`
-	MountNoMatch             string `json:"mountNoMatch"`
-	CAIssuerCertificate      string `json:"caIssuerCertificate"`
-	AdminUsername            string `json:"adminUsername"`
-	AdminSigningIn           string `json:"adminSigningIn"`
-	AdminInvalidateCache     string `json:"adminInvalidateCache"`
-	AdminThresholdsTitle     string `json:"adminThresholdsTitle"`
-	AdminSaving              string `json:"adminSaving"`
-	AdminVaultUnknown        string `json:"adminVaultUnknown"`
-	NavAdmin                 string `json:"navAdmin"`
-	ToastRefreshing          string `json:"toastRefreshing"`
-	ToastRefreshFailed       string `json:"toastRefreshFailed"`
-	SkipToContent            string `json:"skipToContent"`
-	VaultsUnreachable        string `json:"vaultsUnreachable"`
-	VaultsUnreachableHint    string `json:"vaultsUnreachableHint"`
-	TableNoMatch             string `json:"tableNoMatch"`
-	TableEmpty               string `json:"tableEmpty"`
-	TableEmptyHint           string `json:"tableEmptyHint"`
-	FooterMoreInfo           string `json:"footerMoreInfo"`
-	FooterLicense            string `json:"footerLicense"`
-	FooterLabel              string `json:"footerLabel"`
-	StatusConnecting         string `json:"statusConnecting"`
-	StatusNoVaults           string `json:"statusNoVaults"`
-	StatusNoVaultsConfigured string `json:"statusNoVaultsConfigured"`
-	PaginationRange          string `json:"paginationRange"`
-	PaginationResults        string `json:"paginationResults"`
-	PaginationPageSizeAll    string `json:"paginationPageSizeAll"`
+	StatusLabelCritical        string `json:"statusLabelCritical"`
+	StatusLabelWarning         string `json:"statusLabelWarning"`
+	StatusDescValid            string `json:"statusDescValid"`
+	StatusDescWarning          string `json:"statusDescWarning"`
+	StatusDescCritical         string `json:"statusDescCritical"`
+	StatusDescExpired          string `json:"statusDescExpired"`
+	StatusDescRevoked          string `json:"statusDescRevoked"`
+	LabelValidity              string `json:"labelValidity"`
+	LabelCopy                  string `json:"labelCopy"`
+	LabelCopied                string `json:"labelCopied"`
+	LabelCopyPEM               string `json:"labelCopyPem"`
+	ButtonDone                 string `json:"buttonDone"`
+	MountNoMatch               string `json:"mountNoMatch"`
+	CAIssuerCertificate        string `json:"caIssuerCertificate"`
+	AdminUsername              string `json:"adminUsername"`
+	AdminSigningIn             string `json:"adminSigningIn"`
+	AdminInvalidateCache       string `json:"adminInvalidateCache"`
+	AdminThresholdsTitle       string `json:"adminThresholdsTitle"`
+	AdminSaving                string `json:"adminSaving"`
+	AdminVaultUnknown          string `json:"adminVaultUnknown"`
+	NavAdmin                   string `json:"navAdmin"`
+	ToastRefreshing            string `json:"toastRefreshing"`
+	ToastRefreshFailed         string `json:"toastRefreshFailed"`
+	SkipToContent              string `json:"skipToContent"`
+	VaultsUnreachable          string `json:"vaultsUnreachable"`
+	VaultsUnreachableHint      string `json:"vaultsUnreachableHint"`
+	TableNoMatch               string `json:"tableNoMatch"`
+	TableEmpty                 string `json:"tableEmpty"`
+	TableEmptyHint             string `json:"tableEmptyHint"`
+	FooterMoreInfo             string `json:"footerMoreInfo"`
+	FooterLicense              string `json:"footerLicense"`
+	FooterLabel                string `json:"footerLabel"`
+	StatusConnecting           string `json:"statusConnecting"`
+	StatusNoVaults             string `json:"statusNoVaults"`
+	StatusNoVaultsConfigured   string `json:"statusNoVaultsConfigured"`
+	PaginationRange            string `json:"paginationRange"`
+	PaginationResults          string `json:"paginationResults"`
+	PaginationPageSizeAll      string `json:"paginationPageSizeAll"`
+	AdminNavNotifications      string `json:"adminNavNotifications"`
+	AdminWebhookURL            string `json:"adminWebhookURL"`
+	AdminWebhookURLHint        string `json:"adminWebhookURLHint"`
+	AdminWebhookURLPlaceholder string `json:"adminWebhookURLPlaceholder"`
 }
 
 // Response is the payload returned by the /api/i18n endpoint.
@@ -387,44 +391,48 @@ var englishMessages = Messages{
 	AdminVaultTLSOptions:           "TLS options",
 	CopyFailed:                     "Copy failed — clipboard unavailable",
 
-	StatusLabelCritical:      "Critical",
-	StatusLabelWarning:       "Warning",
-	StatusDescValid:          "All good",
-	StatusDescWarning:        "≤ {days} days",
-	StatusDescCritical:       "≤ {days} days",
-	StatusDescExpired:        "Past expiry",
-	StatusDescRevoked:        "Revoked by CA",
-	LabelValidity:            "Validity",
-	LabelCopy:                "Copy",
-	LabelCopied:              "Copied!",
-	LabelCopyPEM:             "Copy PEM",
-	ButtonDone:               "Done",
-	MountNoMatch:             "No mount matches.",
-	CAIssuerCertificate:      "Issuer certificate",
-	AdminUsername:            "Username",
-	AdminSigningIn:           "Signing in…",
-	AdminInvalidateCache:     "Invalidate cache",
-	AdminThresholdsTitle:     "Expiration thresholds (days)",
-	AdminSaving:              "Saving…",
-	AdminVaultUnknown:        "Unknown",
-	NavAdmin:                 "Admin",
-	ToastRefreshing:          "Refreshing…",
-	ToastRefreshFailed:       "Refresh failed",
-	SkipToContent:            "Skip to main content",
-	VaultsUnreachable:        "{count} vault(s) unreachable",
-	VaultsUnreachableHint:    "Showing partial results.",
-	TableNoMatch:             "No certificates match the current filters.",
-	TableEmpty:               "No certificates found.",
-	TableEmptyHint:           "No PKI mount returned any certificates yet.",
-	FooterMoreInfo:           "More info",
-	FooterLicense:            "License",
-	FooterLabel:              "Site information",
-	StatusConnecting:         "connecting…",
-	StatusNoVaults:           "no vaults",
-	StatusNoVaultsConfigured: "No vaults configured.",
-	PaginationRange:          "{start}–{end} of {total}",
-	PaginationResults:        "{count} results",
-	PaginationPageSizeAll:    "All",
+	StatusLabelCritical:        "Critical",
+	StatusLabelWarning:         "Warning",
+	StatusDescValid:            "All good",
+	StatusDescWarning:          "≤ {days} days",
+	StatusDescCritical:         "≤ {days} days",
+	StatusDescExpired:          "Past expiry",
+	StatusDescRevoked:          "Revoked by CA",
+	LabelValidity:              "Validity",
+	LabelCopy:                  "Copy",
+	LabelCopied:                "Copied!",
+	LabelCopyPEM:               "Copy PEM",
+	ButtonDone:                 "Done",
+	MountNoMatch:               "No mount matches.",
+	CAIssuerCertificate:        "Issuer certificate",
+	AdminUsername:              "Username",
+	AdminSigningIn:             "Signing in…",
+	AdminInvalidateCache:       "Invalidate cache",
+	AdminThresholdsTitle:       "Expiration thresholds (days)",
+	AdminSaving:                "Saving…",
+	AdminVaultUnknown:          "Unknown",
+	NavAdmin:                   "Admin",
+	ToastRefreshing:            "Refreshing…",
+	ToastRefreshFailed:         "Refresh failed",
+	SkipToContent:              "Skip to main content",
+	VaultsUnreachable:          "{count} vault(s) unreachable",
+	VaultsUnreachableHint:      "Showing partial results.",
+	TableNoMatch:               "No certificates match the current filters.",
+	TableEmpty:                 "No certificates found.",
+	TableEmptyHint:             "No PKI mount returned any certificates yet.",
+	FooterMoreInfo:             "More info",
+	FooterLicense:              "License",
+	FooterLabel:                "Site information",
+	StatusConnecting:           "connecting…",
+	StatusNoVaults:             "no vaults",
+	StatusNoVaultsConfigured:   "No vaults configured.",
+	PaginationRange:            "{start}–{end} of {total}",
+	PaginationResults:          "{count} results",
+	PaginationPageSizeAll:      "All",
+	AdminNavNotifications:      "Notifications",
+	AdminWebhookURL:            "Webhook URL",
+	AdminWebhookURLHint:        "POSTed a JSON alert when a certificate crosses the warning or critical threshold. Leave blank to disable.",
+	AdminWebhookURLPlaceholder: "Enter a new webhook URL to replace the stored one",
 }
 
 var frenchMessages = Messages{
@@ -586,44 +594,48 @@ var frenchMessages = Messages{
 	AdminVaultTLSOptions:           "Options TLS",
 	CopyFailed:                     "Échec de la copie — presse-papiers indisponible",
 
-	StatusLabelCritical:      "Critique",
-	StatusLabelWarning:       "Avertissement",
-	StatusDescValid:          "Tout va bien",
-	StatusDescWarning:        "≤ {days} jours",
-	StatusDescCritical:       "≤ {days} jours",
-	StatusDescExpired:        "Date dépassée",
-	StatusDescRevoked:        "Révoqué par l'autorité",
-	LabelValidity:            "Validité",
-	LabelCopy:                "Copier",
-	LabelCopied:              "Copié !",
-	LabelCopyPEM:             "Copier le PEM",
-	ButtonDone:               "Terminé",
-	MountNoMatch:             "Aucun montage correspondant.",
-	CAIssuerCertificate:      "Certificat émetteur",
-	AdminUsername:            "Identifiant",
-	AdminSigningIn:           "Connexion…",
-	AdminInvalidateCache:     "Vider le cache",
-	AdminThresholdsTitle:     "Seuils d'expiration (jours)",
-	AdminSaving:              "Enregistrement…",
-	AdminVaultUnknown:        "Inconnu",
-	NavAdmin:                 "Administration",
-	ToastRefreshing:          "Actualisation…",
-	ToastRefreshFailed:       "Échec de l'actualisation",
-	SkipToContent:            "Aller au contenu principal",
-	VaultsUnreachable:        "{count} vault(s) injoignable(s)",
-	VaultsUnreachableHint:    "Résultats partiels affichés.",
-	TableNoMatch:             "Aucun certificat ne correspond aux filtres actuels.",
-	TableEmpty:               "Aucun certificat trouvé.",
-	TableEmptyHint:           "Aucun montage PKI n'a encore renvoyé de certificat.",
-	FooterMoreInfo:           "En savoir plus",
-	FooterLicense:            "Licence",
-	FooterLabel:              "Informations sur le site",
-	StatusConnecting:         "connexion…",
-	StatusNoVaults:           "aucun vault",
-	StatusNoVaultsConfigured: "Aucun vault configuré.",
-	PaginationRange:          "{start}–{end} sur {total}",
-	PaginationResults:        "{count} résultats",
-	PaginationPageSizeAll:    "Tous",
+	StatusLabelCritical:        "Critique",
+	StatusLabelWarning:         "Avertissement",
+	StatusDescValid:            "Tout va bien",
+	StatusDescWarning:          "≤ {days} jours",
+	StatusDescCritical:         "≤ {days} jours",
+	StatusDescExpired:          "Date dépassée",
+	StatusDescRevoked:          "Révoqué par l'autorité",
+	LabelValidity:              "Validité",
+	LabelCopy:                  "Copier",
+	LabelCopied:                "Copié !",
+	LabelCopyPEM:               "Copier le PEM",
+	ButtonDone:                 "Terminé",
+	MountNoMatch:               "Aucun montage correspondant.",
+	CAIssuerCertificate:        "Certificat émetteur",
+	AdminUsername:              "Identifiant",
+	AdminSigningIn:             "Connexion…",
+	AdminInvalidateCache:       "Vider le cache",
+	AdminThresholdsTitle:       "Seuils d'expiration (jours)",
+	AdminSaving:                "Enregistrement…",
+	AdminVaultUnknown:          "Inconnu",
+	NavAdmin:                   "Administration",
+	ToastRefreshing:            "Actualisation…",
+	ToastRefreshFailed:         "Échec de l'actualisation",
+	SkipToContent:              "Aller au contenu principal",
+	VaultsUnreachable:          "{count} vault(s) injoignable(s)",
+	VaultsUnreachableHint:      "Résultats partiels affichés.",
+	TableNoMatch:               "Aucun certificat ne correspond aux filtres actuels.",
+	TableEmpty:                 "Aucun certificat trouvé.",
+	TableEmptyHint:             "Aucun montage PKI n'a encore renvoyé de certificat.",
+	FooterMoreInfo:             "En savoir plus",
+	FooterLicense:              "Licence",
+	FooterLabel:                "Informations sur le site",
+	StatusConnecting:           "connexion…",
+	StatusNoVaults:             "aucun vault",
+	StatusNoVaultsConfigured:   "Aucun vault configuré.",
+	PaginationRange:            "{start}–{end} sur {total}",
+	PaginationResults:          "{count} résultats",
+	PaginationPageSizeAll:      "Tous",
+	AdminNavNotifications:      "Notifications",
+	AdminWebhookURL:            "URL du webhook",
+	AdminWebhookURLHint:        "Reçoit une alerte JSON par POST lorsqu'un certificat franchit le seuil d'avertissement ou critique. Laisser vide pour désactiver.",
+	AdminWebhookURLPlaceholder: "Saisir une nouvelle URL de webhook pour remplacer celle enregistrée",
 }
 
 var spanishMessages = Messages{
@@ -785,44 +797,48 @@ var spanishMessages = Messages{
 	AdminVaultTLSOptions:           "Opciones TLS",
 	CopyFailed:                     "Error al copiar — portapapeles no disponible",
 
-	StatusLabelCritical:      "Crítico",
-	StatusLabelWarning:       "Advertencia",
-	StatusDescValid:          "Todo correcto",
-	StatusDescWarning:        "≤ {days} días",
-	StatusDescCritical:       "≤ {days} días",
-	StatusDescExpired:        "Fecha vencida",
-	StatusDescRevoked:        "Revocado por la autoridad",
-	LabelValidity:            "Validez",
-	LabelCopy:                "Copiar",
-	LabelCopied:              "¡Copiado!",
-	LabelCopyPEM:             "Copiar PEM",
-	ButtonDone:               "Hecho",
-	MountNoMatch:             "Ningún montaje coincide.",
-	CAIssuerCertificate:      "Certificado emisor",
-	AdminUsername:            "Usuario",
-	AdminSigningIn:           "Iniciando sesión…",
-	AdminInvalidateCache:     "Vaciar caché",
-	AdminThresholdsTitle:     "Umbrales de expiración (días)",
-	AdminSaving:              "Guardando…",
-	AdminVaultUnknown:        "Desconocido",
-	NavAdmin:                 "Administración",
-	ToastRefreshing:          "Actualizando…",
-	ToastRefreshFailed:       "Error al actualizar",
-	SkipToContent:            "Ir al contenido principal",
-	VaultsUnreachable:        "{count} vault(s) inaccesible(s)",
-	VaultsUnreachableHint:    "Mostrando resultados parciales.",
-	TableNoMatch:             "Ningún certificado coincide con los filtros actuales.",
-	TableEmpty:               "No se encontraron certificados.",
-	TableEmptyHint:           "Ningún montaje PKI ha devuelto certificados todavía.",
-	FooterMoreInfo:           "Más información",
-	FooterLicense:            "Licencia",
-	FooterLabel:              "Información del sitio",
-	StatusConnecting:         "conectando…",
-	StatusNoVaults:           "sin vaults",
-	StatusNoVaultsConfigured: "Ningún vault configurado.",
-	PaginationRange:          "{start}–{end} de {total}",
-	PaginationResults:        "{count} resultados",
-	PaginationPageSizeAll:    "Todos",
+	StatusLabelCritical:        "Crítico",
+	StatusLabelWarning:         "Advertencia",
+	StatusDescValid:            "Todo correcto",
+	StatusDescWarning:          "≤ {days} días",
+	StatusDescCritical:         "≤ {days} días",
+	StatusDescExpired:          "Fecha vencida",
+	StatusDescRevoked:          "Revocado por la autoridad",
+	LabelValidity:              "Validez",
+	LabelCopy:                  "Copiar",
+	LabelCopied:                "¡Copiado!",
+	LabelCopyPEM:               "Copiar PEM",
+	ButtonDone:                 "Hecho",
+	MountNoMatch:               "Ningún montaje coincide.",
+	CAIssuerCertificate:        "Certificado emisor",
+	AdminUsername:              "Usuario",
+	AdminSigningIn:             "Iniciando sesión…",
+	AdminInvalidateCache:       "Vaciar caché",
+	AdminThresholdsTitle:       "Umbrales de expiración (días)",
+	AdminSaving:                "Guardando…",
+	AdminVaultUnknown:          "Desconocido",
+	NavAdmin:                   "Administración",
+	ToastRefreshing:            "Actualizando…",
+	ToastRefreshFailed:         "Error al actualizar",
+	SkipToContent:              "Ir al contenido principal",
+	VaultsUnreachable:          "{count} vault(s) inaccesible(s)",
+	VaultsUnreachableHint:      "Mostrando resultados parciales.",
+	TableNoMatch:               "Ningún certificado coincide con los filtros actuales.",
+	TableEmpty:                 "No se encontraron certificados.",
+	TableEmptyHint:             "Ningún montaje PKI ha devuelto certificados todavía.",
+	FooterMoreInfo:             "Más información",
+	FooterLicense:              "Licencia",
+	FooterLabel:                "Información del sitio",
+	StatusConnecting:           "conectando…",
+	StatusNoVaults:             "sin vaults",
+	StatusNoVaultsConfigured:   "Ningún vault configurado.",
+	PaginationRange:            "{start}–{end} de {total}",
+	PaginationResults:          "{count} resultados",
+	PaginationPageSizeAll:      "Todos",
+	AdminNavNotifications:      "Notificaciones",
+	AdminWebhookURL:            "URL del webhook",
+	AdminWebhookURLHint:        "Recibe una alerta JSON por POST cuando un certificado cruza el umbral de advertencia o crítico. Dejar en blanco para desactivar.",
+	AdminWebhookURLPlaceholder: "Introduce una nueva URL de webhook para reemplazar la almacenada",
 }
 
 var germanMessages = Messages{
@@ -984,44 +1000,48 @@ var germanMessages = Messages{
 	AdminVaultTLSOptions:           "TLS-Optionen",
 	CopyFailed:                     "Kopieren fehlgeschlagen — Zwischenablage nicht verfügbar",
 
-	StatusLabelCritical:      "Kritisch",
-	StatusLabelWarning:       "Warnung",
-	StatusDescValid:          "Alles in Ordnung",
-	StatusDescWarning:        "≤ {days} Tage",
-	StatusDescCritical:       "≤ {days} Tage",
-	StatusDescExpired:        "Abgelaufen",
-	StatusDescRevoked:        "Von der CA widerrufen",
-	LabelValidity:            "Gültigkeit",
-	LabelCopy:                "Kopieren",
-	LabelCopied:              "Kopiert!",
-	LabelCopyPEM:             "PEM kopieren",
-	ButtonDone:               "Fertig",
-	MountNoMatch:             "Kein Mount gefunden.",
-	CAIssuerCertificate:      "Aussteller-Zertifikat",
-	AdminUsername:            "Benutzername",
-	AdminSigningIn:           "Anmeldung…",
-	AdminInvalidateCache:     "Cache leeren",
-	AdminThresholdsTitle:     "Ablaufschwellen (Tage)",
-	AdminSaving:              "Speichern…",
-	AdminVaultUnknown:        "Unbekannt",
-	NavAdmin:                 "Verwaltung",
-	ToastRefreshing:          "Aktualisierung…",
-	ToastRefreshFailed:       "Aktualisierung fehlgeschlagen",
-	SkipToContent:            "Zum Hauptinhalt springen",
-	VaultsUnreachable:        "{count} Vault(s) nicht erreichbar",
-	VaultsUnreachableHint:    "Teilergebnisse werden angezeigt.",
-	TableEmpty:               "Keine Zertifikate gefunden.",
-	TableEmptyHint:           "Noch hat kein PKI-Mount Zertifikate zurückgegeben.",
-	TableNoMatch:             "Keine Zertifikate entsprechen den aktuellen Filtern.",
-	FooterMoreInfo:           "Mehr Infos",
-	FooterLicense:            "Lizenz",
-	FooterLabel:              "Seiteninformationen",
-	StatusConnecting:         "verbinde…",
-	StatusNoVaults:           "keine Vaults",
-	StatusNoVaultsConfigured: "Keine Vaults konfiguriert.",
-	PaginationRange:          "{start}–{end} von {total}",
-	PaginationResults:        "{count} Ergebnisse",
-	PaginationPageSizeAll:    "Alle",
+	StatusLabelCritical:        "Kritisch",
+	StatusLabelWarning:         "Warnung",
+	StatusDescValid:            "Alles in Ordnung",
+	StatusDescWarning:          "≤ {days} Tage",
+	StatusDescCritical:         "≤ {days} Tage",
+	StatusDescExpired:          "Abgelaufen",
+	StatusDescRevoked:          "Von der CA widerrufen",
+	LabelValidity:              "Gültigkeit",
+	LabelCopy:                  "Kopieren",
+	LabelCopied:                "Kopiert!",
+	LabelCopyPEM:               "PEM kopieren",
+	ButtonDone:                 "Fertig",
+	MountNoMatch:               "Kein Mount gefunden.",
+	CAIssuerCertificate:        "Aussteller-Zertifikat",
+	AdminUsername:              "Benutzername",
+	AdminSigningIn:             "Anmeldung…",
+	AdminInvalidateCache:       "Cache leeren",
+	AdminThresholdsTitle:       "Ablaufschwellen (Tage)",
+	AdminSaving:                "Speichern…",
+	AdminVaultUnknown:          "Unbekannt",
+	NavAdmin:                   "Verwaltung",
+	ToastRefreshing:            "Aktualisierung…",
+	ToastRefreshFailed:         "Aktualisierung fehlgeschlagen",
+	SkipToContent:              "Zum Hauptinhalt springen",
+	VaultsUnreachable:          "{count} Vault(s) nicht erreichbar",
+	VaultsUnreachableHint:      "Teilergebnisse werden angezeigt.",
+	TableEmpty:                 "Keine Zertifikate gefunden.",
+	TableEmptyHint:             "Noch hat kein PKI-Mount Zertifikate zurückgegeben.",
+	TableNoMatch:               "Keine Zertifikate entsprechen den aktuellen Filtern.",
+	FooterMoreInfo:             "Mehr Infos",
+	FooterLicense:              "Lizenz",
+	FooterLabel:                "Seiteninformationen",
+	StatusConnecting:           "verbinde…",
+	StatusNoVaults:             "keine Vaults",
+	StatusNoVaultsConfigured:   "Keine Vaults konfiguriert.",
+	PaginationRange:            "{start}–{end} von {total}",
+	PaginationResults:          "{count} Ergebnisse",
+	PaginationPageSizeAll:      "Alle",
+	AdminNavNotifications:      "Benachrichtigungen",
+	AdminWebhookURL:            "Webhook-URL",
+	AdminWebhookURLHint:        "Erhält einen JSON-Alarm per POST, wenn ein Zertifikat die Warn- oder kritische Schwelle überschreitet. Leer lassen zum Deaktivieren.",
+	AdminWebhookURLPlaceholder: "Neue Webhook-URL eingeben, um die gespeicherte zu ersetzen",
 }
 
 var italianMessages = Messages{
@@ -1183,44 +1203,48 @@ var italianMessages = Messages{
 	AdminVaultTLSOptions:           "Opzioni TLS",
 	CopyFailed:                     "Copia non riuscita — appunti non disponibili",
 
-	StatusLabelCritical:      "Critico",
-	StatusLabelWarning:       "Avviso",
-	StatusDescValid:          "Tutto a posto",
-	StatusDescWarning:        "≤ {days} giorni",
-	StatusDescCritical:       "≤ {days} giorni",
-	StatusDescExpired:        "Data superata",
-	StatusDescRevoked:        "Revocato dalla CA",
-	LabelValidity:            "Validità",
-	LabelCopy:                "Copia",
-	LabelCopied:              "Copiato!",
-	LabelCopyPEM:             "Copia PEM",
-	ButtonDone:               "Fatto",
-	MountNoMatch:             "Nessun mount corrispondente.",
-	CAIssuerCertificate:      "Certificato emittente",
-	AdminUsername:            "Nome utente",
-	AdminSigningIn:           "Accesso…",
-	AdminInvalidateCache:     "Svuota cache",
-	AdminThresholdsTitle:     "Soglie di scadenza (giorni)",
-	AdminSaving:              "Salvataggio…",
-	AdminVaultUnknown:        "Sconosciuto",
-	NavAdmin:                 "Amministrazione",
-	ToastRefreshing:          "Aggiornamento…",
-	ToastRefreshFailed:       "Aggiornamento non riuscito",
-	SkipToContent:            "Vai al contenuto principale",
-	VaultsUnreachable:        "{count} vault non raggiungibile/i",
-	VaultsUnreachableHint:    "Risultati parziali mostrati.",
-	TableNoMatch:             "Nessun certificato corrisponde ai filtri attuali.",
-	TableEmpty:               "Nessun certificato trovato.",
-	TableEmptyHint:           "Nessun mount PKI ha ancora restituito certificati.",
-	FooterMoreInfo:           "Maggiori informazioni",
-	FooterLicense:            "Licenza",
-	FooterLabel:              "Informazioni sul sito",
-	StatusConnecting:         "connessione…",
-	StatusNoVaults:           "nessun vault",
-	StatusNoVaultsConfigured: "Nessun vault configurato.",
-	PaginationRange:          "{start}–{end} di {total}",
-	PaginationResults:        "{count} risultati",
-	PaginationPageSizeAll:    "Tutti",
+	StatusLabelCritical:        "Critico",
+	StatusLabelWarning:         "Avviso",
+	StatusDescValid:            "Tutto a posto",
+	StatusDescWarning:          "≤ {days} giorni",
+	StatusDescCritical:         "≤ {days} giorni",
+	StatusDescExpired:          "Data superata",
+	StatusDescRevoked:          "Revocato dalla CA",
+	LabelValidity:              "Validità",
+	LabelCopy:                  "Copia",
+	LabelCopied:                "Copiato!",
+	LabelCopyPEM:               "Copia PEM",
+	ButtonDone:                 "Fatto",
+	MountNoMatch:               "Nessun mount corrispondente.",
+	CAIssuerCertificate:        "Certificato emittente",
+	AdminUsername:              "Nome utente",
+	AdminSigningIn:             "Accesso…",
+	AdminInvalidateCache:       "Svuota cache",
+	AdminThresholdsTitle:       "Soglie di scadenza (giorni)",
+	AdminSaving:                "Salvataggio…",
+	AdminVaultUnknown:          "Sconosciuto",
+	NavAdmin:                   "Amministrazione",
+	ToastRefreshing:            "Aggiornamento…",
+	ToastRefreshFailed:         "Aggiornamento non riuscito",
+	SkipToContent:              "Vai al contenuto principale",
+	VaultsUnreachable:          "{count} vault non raggiungibile/i",
+	VaultsUnreachableHint:      "Risultati parziali mostrati.",
+	TableNoMatch:               "Nessun certificato corrisponde ai filtri attuali.",
+	TableEmpty:                 "Nessun certificato trovato.",
+	TableEmptyHint:             "Nessun mount PKI ha ancora restituito certificati.",
+	FooterMoreInfo:             "Maggiori informazioni",
+	FooterLicense:              "Licenza",
+	FooterLabel:                "Informazioni sul sito",
+	StatusConnecting:           "connessione…",
+	StatusNoVaults:             "nessun vault",
+	StatusNoVaultsConfigured:   "Nessun vault configurato.",
+	PaginationRange:            "{start}–{end} di {total}",
+	PaginationResults:          "{count} risultati",
+	PaginationPageSizeAll:      "Tutti",
+	AdminNavNotifications:      "Notifiche",
+	AdminWebhookURL:            "URL webhook",
+	AdminWebhookURLHint:        "Riceve un avviso JSON via POST quando un certificato supera la soglia di avviso o critica. Lasciare vuoto per disabilitare.",
+	AdminWebhookURLPlaceholder: "Inserisci un nuovo URL webhook per sostituire quello memorizzato",
 }
 
 // MessagesForLanguage returns the translations for a given language code.

--- a/app/internal/metrics/certificate_collector.go
+++ b/app/internal/metrics/certificate_collector.go
@@ -265,27 +265,7 @@ func (collector *certificateCollector) countStatuses(certificates []certs.Certif
 }
 
 func (collector *certificateCollector) countExpiringSoon(certificates []certs.Certificate, now time.Time) (int, int) {
-	warningCount := 0
-	criticalCount := 0
-	for _, certificate := range certificates {
-		if collector.statusLabel(certificate, now) != "valid" {
-			continue
-		}
-		if certificate.ExpiresAt.IsZero() {
-			continue
-		}
-		daysRemaining := daysUntil(certificate.ExpiresAt.UTC(), now.UTC())
-		if daysRemaining < 0 {
-			continue
-		}
-		if collector.thresholds.Warning > 0 && daysRemaining <= collector.thresholds.Warning {
-			warningCount++
-		}
-		if collector.thresholds.Critical > 0 && daysRemaining <= collector.thresholds.Critical {
-			criticalCount++
-		}
-	}
-	return warningCount, criticalCount
+	return certs.CountExpiring(certificates, collector.thresholds.Warning, collector.thresholds.Critical, now)
 }
 
 func (collector *certificateCollector) getCacheSize() int {

--- a/app/internal/notify/notify.go
+++ b/app/internal/notify/notify.go
@@ -1,0 +1,187 @@
+// Package notify delivers outbound webhook alerts when certificate expiry
+// crosses into the warning or critical threshold, independent of anyone
+// having the dashboard open. See internal/certs.CountExpiring for the
+// threshold math (shared with the Prometheus collector).
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"vcv/internal/certs"
+	"vcv/internal/config"
+	"vcv/internal/logger"
+)
+
+// CertLister lists all certificates the notifier should evaluate. Satisfied
+// by vault.Client.
+type CertLister interface {
+	ListCertificates(ctx context.Context) ([]certs.Certificate, error)
+}
+
+// SettingsLoader returns the current admin settings. Read fresh on every
+// check so a webhook URL or threshold edit takes effect without a restart.
+type SettingsLoader func() (config.SettingsFile, error)
+
+type tier int
+
+const (
+	tierNone tier = iota
+	tierWarning
+	tierCritical
+)
+
+func (t tier) String() string {
+	switch t {
+	case tierCritical:
+		return "critical"
+	case tierWarning:
+		return "warning"
+	default:
+		return "none"
+	}
+}
+
+func currentTier(warning, critical int) tier {
+	if critical > 0 {
+		return tierCritical
+	}
+	if warning > 0 {
+		return tierWarning
+	}
+	return tierNone
+}
+
+const httpTimeout = 10 * time.Second
+
+// errWebhookDeliveryFailed is logged verbatim - it must never wrap the raw
+// transport error, since Go's http.Client embeds the full request URL
+// (which may carry a secret, e.g. a Slack webhook path) in that error text.
+var errWebhookDeliveryFailed = errors.New("webhook request failed")
+
+// Notifier polls certificate expiry state and POSTs a webhook when the
+// overall tier increases. Semantics mirror the frontend's
+// expiry-notify.ts: escalate-only, no repeat alerts at the same tier, reset
+// once expiry clears back to none. The zero value's lastTier (tierNone)
+// means the first Check after startup always notifies if a tier is active,
+// matching the frontend's "always notify on initial load" behavior.
+type Notifier struct {
+	certs    CertLister
+	settings SettingsLoader
+	client   *http.Client
+	now      func() time.Time
+
+	mu       sync.Mutex
+	lastTier tier
+}
+
+// New builds a Notifier. certLister and settingsLoader are read on every
+// Check call so admin edits (webhook URL, thresholds) apply live.
+func New(certLister CertLister, settingsLoader SettingsLoader) *Notifier {
+	return &Notifier{
+		certs:    certLister,
+		settings: settingsLoader,
+		client:   &http.Client{Timeout: httpTimeout},
+		now:      time.Now,
+	}
+}
+
+// Check lists certificates, computes the expiry tier, and delivers a
+// webhook when the tier has increased since the last check. All failures
+// (settings load, cert list, delivery) are logged and swallowed - a broken
+// webhook must never affect the rest of the app.
+func (n *Notifier) Check(ctx context.Context) {
+	settings, err := n.settings()
+	if err != nil {
+		logger.Get().Warn().Err(err).Msg("notify: failed to load settings")
+		return
+	}
+	webhookURL := strings.TrimSpace(settings.Notifications.WebhookURL)
+	if webhookURL == "" {
+		return
+	}
+
+	certificates, err := n.certs.ListCertificates(ctx)
+	if err != nil {
+		logger.Get().Warn().Err(err).Msg("notify: failed to list certificates")
+		return
+	}
+
+	thresholds := settings.Certificates.ExpirationThresholds
+	warning, critical := certs.CountExpiring(certificates, thresholds.Warning, thresholds.Critical, n.now())
+	current := currentTier(warning, critical)
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if current == tierNone {
+		n.lastTier = tierNone
+		return
+	}
+	if current <= n.lastTier {
+		return
+	}
+
+	if deliverErr := n.deliver(ctx, webhookURL, current, warning, critical, thresholds); deliverErr != nil {
+		logger.Get().Warn().Err(deliverErr).Str("tier", current.String()).Msg("notify: webhook delivery failed, will retry next check")
+		return
+	}
+	n.lastTier = current
+}
+
+type webhookPayload struct {
+	// Text is a plain-language summary; Slack, Discord, and Mattermost all
+	// render a top-level "text" field out of the box with no extra config.
+	Text          string            `json:"text"`
+	Tier          string            `json:"tier"`
+	WarningCount  int               `json:"warning_count"`
+	CriticalCount int               `json:"critical_count"`
+	Thresholds    webhookThresholds `json:"thresholds"`
+}
+
+type webhookThresholds struct {
+	WarningDays  int `json:"warning_days"`
+	CriticalDays int `json:"critical_days"`
+}
+
+func (n *Notifier) deliver(ctx context.Context, webhookURL string, current tier, warning, critical int, thresholds config.ExpirationThresholds) error {
+	count, days := warning, thresholds.Warning
+	if current == tierCritical {
+		count, days = critical, thresholds.Critical
+	}
+	payload := webhookPayload{
+		Text:          fmt.Sprintf("%d certificate(s) expiring within %d days or fewer (%s)", count, days, current),
+		Tier:          current.String(),
+		WarningCount:  warning,
+		CriticalCount: critical,
+		Thresholds:    webhookThresholds{WarningDays: thresholds.Warning, CriticalDays: thresholds.Critical},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return errWebhookDeliveryFailed
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return errWebhookDeliveryFailed
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/app/internal/notify/notify.go
+++ b/app/internal/notify/notify.go
@@ -26,9 +26,11 @@ type CertLister interface {
 	ListCertificates(ctx context.Context) ([]certs.Certificate, error)
 }
 
-// SettingsLoader returns the current admin settings. Read fresh on every
-// check so a webhook URL or threshold edit takes effect without a restart.
-type SettingsLoader func() (config.SettingsFile, error)
+// SettingsLoader returns the current app configuration, read fresh from
+// disk. Satisfied by config.Load - passing it directly means a webhook URL
+// or threshold edit via the admin panel takes effect on the next Check
+// without a restart.
+type SettingsLoader func() (config.Config, error)
 
 type tier int
 
@@ -114,7 +116,7 @@ func (n *Notifier) Check(ctx context.Context) {
 		return
 	}
 
-	thresholds := settings.Certificates.ExpirationThresholds
+	thresholds := settings.ExpirationThresholds
 	warning, critical := certs.CountExpiring(certificates, thresholds.Warning, thresholds.Critical, n.now())
 	current := currentTier(warning, critical)
 

--- a/app/internal/notify/notify_test.go
+++ b/app/internal/notify/notify_test.go
@@ -29,10 +29,10 @@ func certExpiringIn(id string, days int) certs.Certificate {
 	return certs.Certificate{ID: id, ExpiresAt: time.Now().Add(time.Duration(days) * 24 * time.Hour)}
 }
 
-func settingsWithWebhook(url string) config.SettingsFile {
-	return config.SettingsFile{
-		Notifications: config.NotificationSettings{WebhookURL: url},
-		Certificates:  config.CertificateSettings{ExpirationThresholds: config.ExpirationThresholds{Warning: 30, Critical: 7}},
+func settingsWithWebhook(url string) config.Config {
+	return config.Config{
+		Notifications:        config.NotificationsConfig{WebhookURL: url},
+		ExpirationThresholds: config.ExpirationThresholds{Warning: 30, Critical: 7},
 	}
 }
 
@@ -45,7 +45,7 @@ func TestNotifier_NoWebhookConfigured_NeverCallsOut(t *testing.T) {
 	defer server.Close()
 
 	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 1)}}
-	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(""), nil }
+	settings := func() (config.Config, error) { return settingsWithWebhook(""), nil }
 	n := New(lister, settings)
 
 	n.Check(context.Background())
@@ -62,7 +62,7 @@ func TestNotifier_EscalatesFromNoneToWarning_Delivers(t *testing.T) {
 	defer server.Close()
 
 	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
-	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	settings := func() (config.Config, error) { return settingsWithWebhook(server.URL), nil }
 	n := New(lister, settings)
 
 	n.Check(context.Background())
@@ -82,7 +82,7 @@ func TestNotifier_SameTierTwice_DeliversOnce(t *testing.T) {
 	defer server.Close()
 
 	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
-	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	settings := func() (config.Config, error) { return settingsWithWebhook(server.URL), nil }
 	n := New(lister, settings)
 
 	n.Check(context.Background())
@@ -103,7 +103,7 @@ func TestNotifier_EscalatesWarningToCritical_DeliversAgain(t *testing.T) {
 	defer server.Close()
 
 	lister := &mutableCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
-	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	settings := func() (config.Config, error) { return settingsWithWebhook(server.URL), nil }
 	n := New(lister, settings)
 
 	n.Check(context.Background()) // none -> warning: delivers
@@ -122,7 +122,7 @@ func TestNotifier_ClearsToNone_ThenReescalates(t *testing.T) {
 	defer server.Close()
 
 	lister := &mutableCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
-	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	settings := func() (config.Config, error) { return settingsWithWebhook(server.URL), nil }
 	n := New(lister, settings)
 
 	n.Check(context.Background()) // none -> warning: delivers (1)
@@ -147,7 +147,7 @@ func TestNotifier_DeliveryFailure_RetriesOnNextCheck(t *testing.T) {
 	defer server.Close()
 
 	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
-	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	settings := func() (config.Config, error) { return settingsWithWebhook(server.URL), nil }
 	n := New(lister, settings)
 
 	n.Check(context.Background()) // fails (500), lastTier stays none
@@ -158,7 +158,7 @@ func TestNotifier_DeliveryFailure_RetriesOnNextCheck(t *testing.T) {
 
 func TestNotifier_SettingsLoadError_NoOp(t *testing.T) {
 	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 1)}}
-	settings := func() (config.SettingsFile, error) { return config.SettingsFile{}, assert.AnError }
+	settings := func() (config.Config, error) { return config.Config{}, assert.AnError }
 	n := New(lister, settings)
 
 	assert.NotPanics(t, func() { n.Check(context.Background()) })
@@ -166,7 +166,7 @@ func TestNotifier_SettingsLoadError_NoOp(t *testing.T) {
 
 func TestNotifier_CertListError_NoOp(t *testing.T) {
 	lister := fakeCertLister{err: assert.AnError}
-	settings := func() (config.SettingsFile, error) { return settingsWithWebhook("https://example.com/hook"), nil }
+	settings := func() (config.Config, error) { return settingsWithWebhook("https://example.com/hook"), nil }
 	n := New(lister, settings)
 
 	assert.NotPanics(t, func() { n.Check(context.Background()) })
@@ -179,7 +179,7 @@ func TestNotifier_CertListError_NoOp(t *testing.T) {
 func TestNotifier_DeliveryErrorNeverLeaksURL(t *testing.T) {
 	const secretURL = "http://127.0.0.1:1/services/T000SECRET/B111SECRET/XXXXSECRETTOKEN"
 	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
-	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(secretURL), nil }
+	settings := func() (config.Config, error) { return settingsWithWebhook(secretURL), nil }
 	n := New(lister, settings)
 
 	err := n.deliver(context.Background(), secretURL, tierWarning, 1, 0, config.ExpirationThresholds{Warning: 30, Critical: 7})

--- a/app/internal/notify/notify_test.go
+++ b/app/internal/notify/notify_test.go
@@ -1,0 +1,198 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vcv/internal/certs"
+	"vcv/internal/config"
+)
+
+type fakeCertLister struct {
+	certificates []certs.Certificate
+	err          error
+}
+
+func (f fakeCertLister) ListCertificates(_ context.Context) ([]certs.Certificate, error) {
+	return f.certificates, f.err
+}
+
+func certExpiringIn(id string, days int) certs.Certificate {
+	return certs.Certificate{ID: id, ExpiresAt: time.Now().Add(time.Duration(days) * 24 * time.Hour)}
+}
+
+func settingsWithWebhook(url string) config.SettingsFile {
+	return config.SettingsFile{
+		Notifications: config.NotificationSettings{WebhookURL: url},
+		Certificates:  config.CertificateSettings{ExpirationThresholds: config.ExpirationThresholds{Warning: 30, Critical: 7}},
+	}
+}
+
+func TestNotifier_NoWebhookConfigured_NeverCallsOut(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 1)}}
+	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(""), nil }
+	n := New(lister, settings)
+
+	n.Check(context.Background())
+
+	assert.Equal(t, int32(0), callCount.Load())
+}
+
+func TestNotifier_EscalatesFromNoneToWarning_Delivers(t *testing.T) {
+	var received webhookPayload
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&received))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
+	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	n := New(lister, settings)
+
+	n.Check(context.Background())
+
+	assert.Equal(t, "warning", received.Tier)
+	assert.Equal(t, 1, received.WarningCount)
+	assert.Equal(t, 0, received.CriticalCount)
+	assert.Contains(t, received.Text, "1 certificate(s)")
+}
+
+func TestNotifier_SameTierTwice_DeliversOnce(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
+	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	n := New(lister, settings)
+
+	n.Check(context.Background())
+	n.Check(context.Background())
+	n.Check(context.Background())
+
+	assert.Equal(t, int32(1), callCount.Load())
+}
+
+func TestNotifier_EscalatesWarningToCritical_DeliversAgain(t *testing.T) {
+	var tiers []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload webhookPayload
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		tiers = append(tiers, payload.Tier)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	lister := &mutableCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
+	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	n := New(lister, settings)
+
+	n.Check(context.Background()) // none -> warning: delivers
+	lister.certificates = []certs.Certificate{certExpiringIn("a", 3)}
+	n.Check(context.Background()) // warning -> critical: delivers
+
+	assert.Equal(t, []string{"warning", "critical"}, tiers)
+}
+
+func TestNotifier_ClearsToNone_ThenReescalates(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	lister := &mutableCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
+	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	n := New(lister, settings)
+
+	n.Check(context.Background()) // none -> warning: delivers (1)
+	lister.certificates = []certs.Certificate{certExpiringIn("a", 400)}
+	n.Check(context.Background()) // warning -> none: resets, no delivery
+	lister.certificates = []certs.Certificate{certExpiringIn("a", 20)}
+	n.Check(context.Background()) // none -> warning again: delivers (2)
+
+	assert.Equal(t, int32(2), callCount.Load())
+}
+
+func TestNotifier_DeliveryFailure_RetriesOnNextCheck(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
+	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(server.URL), nil }
+	n := New(lister, settings)
+
+	n.Check(context.Background()) // fails (500), lastTier stays none
+	n.Check(context.Background()) // retries, succeeds
+
+	assert.Equal(t, int32(2), callCount.Load())
+}
+
+func TestNotifier_SettingsLoadError_NoOp(t *testing.T) {
+	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 1)}}
+	settings := func() (config.SettingsFile, error) { return config.SettingsFile{}, assert.AnError }
+	n := New(lister, settings)
+
+	assert.NotPanics(t, func() { n.Check(context.Background()) })
+}
+
+func TestNotifier_CertListError_NoOp(t *testing.T) {
+	lister := fakeCertLister{err: assert.AnError}
+	settings := func() (config.SettingsFile, error) { return settingsWithWebhook("https://example.com/hook"), nil }
+	n := New(lister, settings)
+
+	assert.NotPanics(t, func() { n.Check(context.Background()) })
+}
+
+// TestNotifier_DeliveryErrorNeverLeaksURL guards the specific security property
+// that matters here: a Slack-style webhook URL embeds an auth token in its
+// path, and Go's http.Client wraps unreachable-host errors with the full
+// request URL. deliver() must never let that raw error escape.
+func TestNotifier_DeliveryErrorNeverLeaksURL(t *testing.T) {
+	const secretURL = "http://127.0.0.1:1/services/T000SECRET/B111SECRET/XXXXSECRETTOKEN"
+	lister := fakeCertLister{certificates: []certs.Certificate{certExpiringIn("a", 20)}}
+	settings := func() (config.SettingsFile, error) { return settingsWithWebhook(secretURL), nil }
+	n := New(lister, settings)
+
+	err := n.deliver(context.Background(), secretURL, tierWarning, 1, 0, config.ExpirationThresholds{Warning: 30, Critical: 7})
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "SECRET")
+	assert.NotContains(t, err.Error(), secretURL)
+}
+
+type mutableCertLister struct {
+	certificates []certs.Certificate
+}
+
+func (m *mutableCertLister) ListCertificates(_ context.Context) ([]certs.Certificate, error) {
+	return m.certificates, nil
+}

--- a/app/web/frontend/src/lib/components/admin/AdminPanel.svelte
+++ b/app/web/frontend/src/lib/components/admin/AdminPanel.svelte
@@ -38,11 +38,15 @@
 
   let working = $state<SettingsFile>(untrack(() => $state.snapshot(settings)))
   let lastSyncedRef: SettingsFile | null = null
+  // The server always returns a masked (empty) webhook URL, same as vault tokens.
+  // Track the input separately so a successful save doesn't leave a stale value.
+  let webhookInput = $state(untrack(() => settings.notifications?.webhook_url ?? ''))
 
   $effect(() => {
     if (settings !== lastSyncedRef) {
       lastSyncedRef = settings
       working = $state.snapshot(settings)
+      webhookInput = settings.notifications?.webhook_url ?? ''
     }
   })
 
@@ -68,6 +72,11 @@
   }
 
   const corsText = $derived((working.cors.allowed_origins ?? []).join(', '))
+
+  function updateWebhookURL(value: string): void {
+    webhookInput = value
+    working = { ...working, notifications: { ...working.notifications, webhook_url: value } }
+  }
 
   function updateCors(value: string): void {
     working = {
@@ -112,6 +121,7 @@
     { id: 'thresholds', label: i18n.t('adminNavThresholds', 'Thresholds') },
     { id: 'metrics', label: i18n.t('adminNavMetrics', 'Metrics') },
     { id: 'cors', label: i18n.t('adminNavCors', 'CORS') },
+    { id: 'notifications', label: i18n.t('adminNavNotifications', 'Notifications') },
     { id: 'vaults', label: i18n.t('adminNavVaults', 'Vaults') },
   ])
 </script>
@@ -239,6 +249,23 @@
             value={corsText}
             placeholder="https://app.example.com, https://other.example.com"
             oninput={(event) => updateCors((event.target as HTMLInputElement).value)}
+          />
+        </div>
+      </section>
+
+      <hr class="adm-divider" />
+
+      <!-- Section: Notifications -->
+      <section class="adm-section" id="notifications">
+        <div class="adm-section-head">
+          <h2 class="adm-section-title">{i18n.t('adminWebhookURL', 'Webhook URL')}</h2>
+          <p class="adm-section-hint">{i18n.t('adminWebhookURLHint', 'POSTed a JSON alert when a certificate crosses the warning or critical threshold. Leave blank to disable.')}</p>
+        </div>
+        <div class="adm-field">
+          <Input
+            value={webhookInput}
+            placeholder={i18n.t('adminWebhookURLPlaceholder', 'Enter a new webhook URL to replace the stored one')}
+            oninput={(event) => updateWebhookURL((event.target as HTMLInputElement).value)}
           />
         </div>
       </section>

--- a/app/web/frontend/src/lib/components/admin/AdminPanel.test.ts
+++ b/app/web/frontend/src/lib/components/admin/AdminPanel.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/svelte'
+import type { SettingsFile } from '$lib/types'
+
+vi.mock('$lib/stores/i18n.svelte', () => ({
+  getI18n: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}))
+
+import AdminPanel from '$lib/components/admin/AdminPanel.svelte'
+
+function settings(overrides: Partial<SettingsFile> = {}): SettingsFile {
+  return {
+    app: { env: 'dev', port: 52000 },
+    certificates: { expiration_thresholds: { critical: 7, warning: 30 } },
+    metrics: {},
+    cors: {},
+    notifications: { webhook_url: '' },
+    vaults: [],
+    ...overrides,
+  }
+}
+
+function baseProps(settingsOverrides: Partial<SettingsFile> = {}) {
+  return {
+    settings: settings(settingsOverrides),
+    statuses: [],
+    loading: false,
+    error: null,
+    successMessage: null,
+    onSave: vi.fn(),
+    onAddVault: vi.fn(),
+    onRemoveVault: vi.fn(),
+    onInvalidateCache: vi.fn(),
+    onLogout: vi.fn(),
+  }
+}
+
+describe('AdminPanel webhook URL field', () => {
+  it('starts empty when the server has no webhook configured', () => {
+    render(AdminPanel, { props: baseProps() })
+
+    const input = screen.getByPlaceholderText('Enter a new webhook URL to replace the stored one') as HTMLInputElement
+    expect(input.value).toBe('')
+  })
+
+  it('submits the entered webhook URL on save', async () => {
+    const onSave = vi.fn()
+    render(AdminPanel, { props: { ...baseProps(), onSave } })
+
+    const input = screen.getByPlaceholderText('Enter a new webhook URL to replace the stored one')
+    await fireEvent.input(input, { target: { value: 'https://hooks.example.com/new' } })
+
+    const form = input.closest('form')
+    expect(form).not.toBeNull()
+    await fireEvent.submit(form as HTMLFormElement)
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    const saved = onSave.mock.calls[0][0] as SettingsFile
+    expect(saved.notifications?.webhook_url).toBe('https://hooks.example.com/new')
+  })
+
+  it('resets the input to empty when new (masked) settings arrive after save', async () => {
+    const { rerender } = render(AdminPanel, { props: baseProps() })
+
+    const input = screen.getByPlaceholderText('Enter a new webhook URL to replace the stored one') as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://hooks.example.com/typed' } })
+    expect(input.value).toBe('https://hooks.example.com/typed')
+
+    // Server always returns a masked (empty) webhook_url, same as vault tokens.
+    await rerender({ ...baseProps(), settings: settings({ notifications: { webhook_url: '' } }) })
+
+    expect((screen.getByPlaceholderText('Enter a new webhook URL to replace the stored one') as HTMLInputElement).value).toBe('')
+  })
+})

--- a/app/web/frontend/src/lib/types.ts
+++ b/app/web/frontend/src/lib/types.ts
@@ -96,6 +96,10 @@ export interface CORSSettings {
   allow_credentials?: boolean
 }
 
+export interface NotificationSettings {
+  webhook_url?: string
+}
+
 export interface AppSettings {
   env: string
   port: number
@@ -111,6 +115,7 @@ export interface SettingsFile {
   certificates: CertificateSettings
   metrics: MetricsSettings
   cors: CORSSettings
+  notifications?: NotificationSettings
   vaults: VaultInstance[]
 }
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -29,6 +29,9 @@
     ],
     "allow_credentials": true
   },
+  "notifications": {
+    "webhook_url": ""
+  },
   "vaults": [
     {
       "id": "vault-main",


### PR DESCRIPTION
## Summary

Implements DIRECTION-02 from the /improve audit: the only expiry signal today is an in-tab toast or a hand-rolled Prometheus/Alertmanager stack, so teams without that stack have no way to be proactively notified. This adds a built-in outbound webhook as a second, independent path.

### Backend
- `certs.CountExpiring` — extracted from the metrics collector's private `countExpiringSoon` (its only call site) so the notifier reuses the exact same warning/critical threshold math instead of duplicating it. Refactor only, collector tests unchanged.
- `config.Notifications.WebhookURL` — new setting (`notifications.webhook_url`), validated on admin save as an absolute http(s) URL or empty (disables delivery).
- `internal/notify.Notifier` — polls certs, computes the tier, POSTs a Slack-compatible JSON payload (`text` field renders as-is in Slack/Discord/Mattermost) when the tier **escalates**. Semantics mirror the frontend's `expiry-notify.ts` exactly: one alert per tier, resets once expiry clears back to none. Settings/certs are read fresh every check, so admin edits apply without a restart. All failures are logged and swallowed — a broken webhook can't affect the rest of the app.
- Wired into `main.go`: one check on startup, then every 15 minutes, stopped via context alongside the existing graceful-shutdown path.
- Admin API masks the webhook URL like a vault token (many providers embed an auth token in the path) — blanked on GET, preserved on save when blank/masked. Generalized `maskVaultTokens`/`isBlankOrMaskedToken` → `maskSecrets`/`isBlankOrMaskedSecret` since they're now shared by two secret types.

### Frontend
- Admin panel gets a Notifications section (masked-input pattern identical to vault tokens).
- New i18n keys across all 5 languages, guarded by the i18n completeness test from an earlier PR.

### Docs
- `ALERTING.md`: new webhook section ahead of the existing Prometheus/Alertmanager one, both presented as independent options.
- `app/README.md`: schema entry + a security note that this is the app's first outbound network call, and why that's an acceptable trust boundary (operator-configured, same level as a Vault address or CORS origin).
- In-app admin docs (`internal/docs/ADMIN.md`) and `settings.example.json` updated to match.

### Security note worth a reviewer's eye
`errWebhookDeliveryFailed` is deliberately generic rather than wrapping the raw transport error — Go's `http.Client` embeds the full request URL in connection-failure errors, and a webhook URL commonly carries an auth token in its path. Covered by `TestNotifier_DeliveryErrorNeverLeaksURL`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `make go-lint-full` — 0 issues
- [x] `go test ./... -race` — 569 passed (16 packages), including:
  - `certs.CountExpiring` table tests
  - `notify` package: escalate-only semantics, tier reset, delivery-failure retry, settings/cert-list error handling, URL-leak guard
  - `admin_api` merge/mask tests for the webhook field
  - `validateSettings` table tests for the URL validation
- [x] `pnpm check` — 0 errors; `pnpm test` — 109 passed (18 files), including a new `AdminPanel.test.ts` scoped to the webhook field; `pnpm build` — succeeds