### PR TITLE
feat(web): redesign admin panel to match main dashboard visual language

### DIFF
--- a/app/web/frontend/src/lib/components/ErrorBanner.svelte
+++ b/app/web/frontend/src/lib/components/ErrorBanner.svelte
@@ -3,7 +3,7 @@
 
   type Props = {
     message: string
-    variant?: 'error' | 'warning'
+    variant?: 'error' | 'warning' | 'success'
     onDismiss?: () => void
   }
 

--- a/app/web/frontend/src/lib/components/admin/AdminDocsModal.svelte
+++ b/app/web/frontend/src/lib/components/admin/AdminDocsModal.svelte
@@ -38,16 +38,16 @@
 <Dialog.Root {open} {onOpenChange}>
   <Dialog.Content class="max-w-3xl p-0 overflow-hidden">
     <Dialog.Header class="px-6 pt-6">
-      <Dialog.Title class="flex items-center gap-2">
-        <BookOpen class="h-5 w-5 text-primary" />
+      <Dialog.Title class="flex items-center gap-2" style="color: var(--vcv-color-text-strong)">
+        <BookOpen class="h-5 w-5" style="color: var(--vcv-color-primary)" />
         {i18n.t('adminDocsTitle', 'Documentation')}
       </Dialog.Title>
     </Dialog.Header>
 
     {#if loading && html === null}
-      <div class="px-6 py-8 text-sm text-muted-foreground">{i18n.t('labelLoading', 'Loading…')}</div>
+      <div class="px-6 py-8" style="font-size: 0.875rem; color: var(--vcv-color-muted)">{i18n.t('labelLoading', 'Loading…')}</div>
     {:else if error}
-      <div class="px-6 py-8 text-sm text-destructive">{error}</div>
+      <div class="px-6 py-8" style="font-size: 0.875rem; color: var(--vcv-color-danger)">{error}</div>
     {:else if html !== null}
       <ScrollArea class="max-h-[75vh]">
         <!-- Trusted: rendered from the binary-embedded ADMIN.md, not user input. -->
@@ -84,18 +84,18 @@
     margin: 0.25rem 0;
   }
   .vcv-docs :global(a) {
-    color: var(--primary);
+    color: var(--vcv-color-primary);
     text-decoration: underline;
   }
   .vcv-docs :global(code) {
-    font-family: var(--font-mono, ui-monospace, monospace);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.8125rem;
-    background: color-mix(in oklab, var(--muted) 60%, transparent);
+    background: var(--vcv-color-surface-muted);
     padding: 0.1em 0.35em;
     border-radius: 0.25rem;
   }
   .vcv-docs :global(pre) {
-    background: color-mix(in oklab, var(--muted) 60%, transparent);
+    background: var(--vcv-color-surface-muted);
     padding: 0.75rem 1rem;
     border-radius: 0.5rem;
     overflow-x: auto;
@@ -106,10 +106,10 @@
     padding: 0;
   }
   .vcv-docs :global(blockquote) {
-    border-left: 3px solid var(--border);
+    border-left: 3px solid var(--vcv-color-border);
     padding-left: 0.75rem;
     margin: 0.75rem 0;
-    color: var(--muted-foreground);
+    color: var(--vcv-color-muted);
     font-size: 0.85rem;
   }
 </style>

--- a/app/web/frontend/src/lib/components/admin/AdminLogin.svelte
+++ b/app/web/frontend/src/lib/components/admin/AdminLogin.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ShieldCheck from '@lucide/svelte/icons/shield-check'
   import { Button } from '$lib/components/ui/button'
   import { Input } from '$lib/components/ui/input'
   import { Label } from '$lib/components/ui/label'
@@ -25,51 +26,50 @@
 
 <div class="admin-login-root">
   <div class="admin-login-brand">
-    <div class="admin-login-icon">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-        <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-      </svg>
-    </div>
+    <span class="vcv-brand-mark admin-login-mark" aria-hidden="true">
+      <ShieldCheck class="h-6 w-6" />
+    </span>
     <div class="admin-login-wordmark">VCV Admin</div>
     <div class="admin-login-path">/admin</div>
   </div>
 
-  <form class="admin-login-form" onsubmit={submit} autocomplete="on">
-    <div class="admin-login-field">
-      <Label for="username" class="admin-login-label">{i18n.t('adminUsername', 'Username')}</Label>
-      <Input
-        id="username"
-        type="text"
-        bind:value={username}
-        required
-        autocomplete="username"
-        class="admin-login-input"
-      />
-    </div>
+  <div class="admin-login-card">
+    <form class="admin-login-form" onsubmit={submit} autocomplete="on">
+      <div class="admin-login-field">
+        <Label for="username" class="admin-login-label">{i18n.t('adminUsername', 'Username')}</Label>
+        <Input
+          id="username"
+          type="text"
+          bind:value={username}
+          required
+          autocomplete="username"
+          class="admin-login-input"
+        />
+      </div>
 
-    <div class="admin-login-field">
-      <Label for="password" class="admin-login-label">{i18n.t('adminPassword', 'Password')}</Label>
-      <Input
-        id="password"
-        type="password"
-        bind:value={password}
-        required
-        autocomplete="current-password"
-        class="admin-login-input"
-      />
-    </div>
+      <div class="admin-login-field">
+        <Label for="password" class="admin-login-label">{i18n.t('adminPassword', 'Password')}</Label>
+        <Input
+          id="password"
+          type="password"
+          bind:value={password}
+          required
+          autocomplete="current-password"
+          class="admin-login-input"
+        />
+      </div>
 
-    {#if error}
-      <p class="admin-login-error" role="alert">{error}</p>
-    {/if}
+      {#if error}
+        <p class="admin-login-error" role="alert">{error}</p>
+      {/if}
 
-    <Button type="submit" class="admin-login-submit" disabled={loading}>
-      {loading ? i18n.t('adminSigningIn', 'Signing in…') : i18n.t('adminLogin', 'Sign In')}
-    </Button>
+      <Button type="submit" class="admin-login-submit" disabled={loading}>
+        {loading ? i18n.t('adminSigningIn', 'Signing in…') : i18n.t('adminLogin', 'Sign In')}
+      </Button>
 
-    <a href="/" class="admin-login-back">{i18n.t('adminBackToVCV', 'Back to VCV')}</a>
-  </form>
+      <a href="/" class="admin-login-back">{i18n.t('adminBackToVCV', 'Back to VCV')}</a>
+    </form>
+  </div>
 </div>
 
 <style>
@@ -91,16 +91,10 @@
     margin-bottom: 2.5rem;
   }
 
-  .admin-login-icon {
-    width: 2.5rem;
-    height: 2.5rem;
-    color: var(--vcv-color-primary);
+  .admin-login-mark {
+    width: 3.25rem;
+    height: 3.25rem;
     margin-bottom: 0.25rem;
-  }
-
-  .admin-login-icon svg {
-    width: 100%;
-    height: 100%;
   }
 
   .admin-login-wordmark {
@@ -117,9 +111,17 @@
     letter-spacing: 0.04em;
   }
 
-  .admin-login-form {
+  .admin-login-card {
     width: 100%;
     max-width: 22rem;
+    padding: 1.75rem;
+    background: var(--vcv-color-surface);
+    border: 1px solid var(--vcv-color-border);
+    border-radius: var(--vcv-radius-lg);
+    box-shadow: var(--vcv-shadow-card);
+  }
+
+  .admin-login-form {
     display: flex;
     flex-direction: column;
     gap: 1rem;

--- a/app/web/frontend/src/lib/components/admin/AdminPanel.svelte
+++ b/app/web/frontend/src/lib/components/admin/AdminPanel.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
   import { untrack } from 'svelte'
+  import ShieldCheck from '@lucide/svelte/icons/shield-check'
+  import BookOpen from '@lucide/svelte/icons/book-open'
+  import RefreshCw from '@lucide/svelte/icons/refresh-cw'
+  import LogOut from '@lucide/svelte/icons/log-out'
+  import Clock from '@lucide/svelte/icons/clock'
+  import Activity from '@lucide/svelte/icons/activity'
+  import Globe from '@lucide/svelte/icons/globe'
+  import Bell from '@lucide/svelte/icons/bell'
+  import Server from '@lucide/svelte/icons/server'
   import { Button } from '$lib/components/ui/button'
   import { Input } from '$lib/components/ui/input'
   import { Label } from '$lib/components/ui/label'
   import VaultEditor from './VaultEditor.svelte'
   import AdminDocsModal from './AdminDocsModal.svelte'
+  import ToggleSwitch from './ToggleSwitch.svelte'
+  import ErrorBanner from '$lib/components/ErrorBanner.svelte'
   import { getI18n } from '$lib/stores/i18n.svelte'
   import type { AdminVaultStatus, SettingsFile, VaultInstance } from '$lib/types'
 
@@ -118,42 +129,48 @@
   }
 
   const navItems = $derived([
-    { id: 'thresholds', label: i18n.t('adminNavThresholds', 'Thresholds') },
-    { id: 'metrics', label: i18n.t('adminNavMetrics', 'Metrics') },
-    { id: 'cors', label: i18n.t('adminNavCors', 'CORS') },
-    { id: 'notifications', label: i18n.t('adminNavNotifications', 'Notifications') },
-    { id: 'vaults', label: i18n.t('adminNavVaults', 'Vaults') },
+    { id: 'thresholds', label: i18n.t('adminNavThresholds', 'Thresholds'), icon: Clock },
+    { id: 'metrics', label: i18n.t('adminNavMetrics', 'Metrics'), icon: Activity },
+    { id: 'cors', label: i18n.t('adminNavCors', 'CORS'), icon: Globe },
+    { id: 'notifications', label: i18n.t('adminNavNotifications', 'Notifications'), icon: Bell },
+    { id: 'vaults', label: i18n.t('adminNavVaults', 'Vaults'), icon: Server },
   ])
 </script>
 
 <div class="adm-layout">
   <!-- Top bar -->
   <header class="adm-topbar">
-    <div class="adm-topbar-left">
-      <span class="adm-topbar-title">VCV Admin</span>
-      <span class="adm-topbar-sep">/</span>
-      <span class="adm-topbar-sub">{i18n.t('adminTitle', 'Settings')}</span>
+    <div class="vcv-header-bar adm-topbar-bar">
+      <div class="vcv-header-brand">
+        <span class="vcv-brand-mark" aria-hidden="true">
+          <ShieldCheck class="h-5 w-5" />
+        </span>
+        <div class="vcv-brand-text">
+          <h1 class="vcv-title">VCV Admin</h1>
+          <p class="vcv-title-subtitle">{i18n.t('adminTitle', 'Settings')}</p>
+        </div>
+      </div>
+      <nav class="vcv-header-actions">
+        <a href="/" class="adm-action-link">{i18n.t('adminBackToVCV', 'Back to VCV')}</a>
+        <button type="button" class="vcv-button vcv-button-icon" title={i18n.t('adminDocsTitle', 'Documentation')} aria-label={i18n.t('adminDocsTitle', 'Documentation')} onclick={openDocs}>
+          <BookOpen class="h-4 w-4" />
+        </button>
+        <button type="button" class="vcv-button vcv-button-icon" title={i18n.t('adminInvalidateCache', 'Flush cache')} aria-label={i18n.t('adminInvalidateCache', 'Flush cache')} onclick={onInvalidateCache}>
+          <RefreshCw class="h-4 w-4" />
+        </button>
+        <button type="button" class="vcv-button vcv-button-icon" title={i18n.t('adminLogout', 'Sign out')} aria-label={i18n.t('adminLogout', 'Sign out')} onclick={onLogout}>
+          <LogOut class="h-4 w-4" />
+        </button>
+      </nav>
     </div>
-    <nav class="adm-topbar-actions">
-      <a href="/" class="adm-action-link">{i18n.t('adminBackToVCV', 'Back to VCV')}</a>
-      <button type="button" class="adm-action-link" aria-label={i18n.t('adminDocsTitle', 'Documentation')} onclick={openDocs}>
-        {i18n.t('adminDocsTitle', 'Docs')}
-      </button>
-      <button type="button" class="adm-action-btn adm-action-btn--secondary" aria-label={i18n.t('adminInvalidateCache', 'Flush cache')} onclick={onInvalidateCache}>
-        {i18n.t('adminInvalidateCache', 'Flush cache')}
-      </button>
-      <button type="button" class="adm-action-btn adm-action-btn--ghost" aria-label={i18n.t('adminLogout', 'Sign out')} onclick={onLogout}>
-        {i18n.t('adminLogout', 'Sign out')}
-      </button>
-    </nav>
   </header>
 
   <!-- Feedback bar -->
   {#if error}
-    <div class="adm-feedback adm-feedback--error" role="alert">{error}</div>
+    <ErrorBanner message={error} variant="error" />
   {/if}
   {#if successMessage}
-    <div class="adm-feedback adm-feedback--success" role="status">{successMessage}</div>
+    <ErrorBanner message={successMessage} variant="success" />
   {/if}
 
   <!-- Body: nav + content -->
@@ -161,7 +178,11 @@
     <!-- Sticky left nav -->
     <aside class="adm-sidenav">
       {#each navItems as item}
-        <a href="#{item.id}" class="adm-sidenav-item">{item.label}</a>
+        {@const Icon = item.icon}
+        <a href="#{item.id}" class="adm-sidenav-item">
+          <Icon class="h-3.5 w-3.5" aria-hidden="true" />
+          {item.label}
+        </a>
       {/each}
     </aside>
 
@@ -171,7 +192,7 @@
       <!-- Section: Thresholds -->
       <section class="adm-section" id="thresholds">
         <div class="adm-section-head">
-          <h2 class="adm-section-title">{i18n.t('adminThresholdsTitle', 'Expiration thresholds')}</h2>
+          <h2 class="adm-section-title"><Clock class="h-3.5 w-3.5" aria-hidden="true" />{i18n.t('adminThresholdsTitle', 'Expiration thresholds')}</h2>
           <p class="adm-section-hint">{i18n.t('adminThresholdsHint', 'Days before a certificate is flagged.')}</p>
         </div>
         <div class="adm-grid adm-grid--2">
@@ -203,17 +224,15 @@
       <!-- Section: Metrics -->
       <section class="adm-section" id="metrics">
         <div class="adm-section-head">
-          <h2 class="adm-section-title">{i18n.t('adminMetrics', 'Metrics')}</h2>
+          <h2 class="adm-section-title"><Activity class="h-3.5 w-3.5" aria-hidden="true" />{i18n.t('adminMetrics', 'Metrics')}</h2>
           <p class="adm-section-hint">{i18n.t('adminMetricsHint', 'Prometheus scrape configuration.')}</p>
         </div>
         <div class="adm-toggles">
           <label class="adm-toggle">
-            <input
-              type="checkbox"
+            <ToggleSwitch
               name="metrics_per_certificate"
-              class="adm-toggle-input"
               checked={working.metrics.per_certificate ?? false}
-              onchange={(event) => updateMetric('per_certificate', (event.target as HTMLInputElement).checked)}
+              onCheckedChange={(checked) => updateMetric('per_certificate', checked)}
             />
             <div class="adm-toggle-body">
               <span class="adm-toggle-label">{i18n.t('adminMetricsPerCertificate', 'Per-certificate metrics')}</span>
@@ -221,12 +240,10 @@
             </div>
           </label>
           <label class="adm-toggle">
-            <input
-              type="checkbox"
+            <ToggleSwitch
               name="metrics_enhanced"
-              class="adm-toggle-input"
               checked={working.metrics.enhanced_metrics ?? true}
-              onchange={(event) => updateMetric('enhanced_metrics', (event.target as HTMLInputElement).checked)}
+              onCheckedChange={(checked) => updateMetric('enhanced_metrics', checked)}
             />
             <div class="adm-toggle-body">
               <span class="adm-toggle-label">{i18n.t('adminMetricsEnhanced', 'Enhanced metrics')}</span>
@@ -241,7 +258,7 @@
       <!-- Section: CORS -->
       <section class="adm-section" id="cors">
         <div class="adm-section-head">
-          <h2 class="adm-section-title">{i18n.t('adminCORSOrigins', 'CORS origins')}</h2>
+          <h2 class="adm-section-title"><Globe class="h-3.5 w-3.5" aria-hidden="true" />{i18n.t('adminCORSOrigins', 'CORS origins')}</h2>
           <p class="adm-section-hint">{i18n.t('adminCORSOriginsHint', 'Comma-separated list of allowed origins.')}</p>
         </div>
         <div class="adm-field">
@@ -258,7 +275,7 @@
       <!-- Section: Notifications -->
       <section class="adm-section" id="notifications">
         <div class="adm-section-head">
-          <h2 class="adm-section-title">{i18n.t('adminWebhookURL', 'Webhook URL')}</h2>
+          <h2 class="adm-section-title"><Bell class="h-3.5 w-3.5" aria-hidden="true" />{i18n.t('adminWebhookURL', 'Webhook URL')}</h2>
           <p class="adm-section-hint">{i18n.t('adminWebhookURLHint', 'POSTed a JSON alert when a certificate crosses the warning or critical threshold. Leave blank to disable.')}</p>
         </div>
         <div class="adm-field">
@@ -277,7 +294,7 @@
         <div class="adm-section-head">
           <div class="adm-section-head-row">
             <div>
-              <h2 class="adm-section-title">{i18n.t('adminVaults', 'Vaults')}</h2>
+              <h2 class="adm-section-title"><Server class="h-3.5 w-3.5" aria-hidden="true" />{i18n.t('adminVaults', 'Vaults')}</h2>
               <p class="adm-section-hint">{i18n.t('adminVaultsHint', 'Vault and OpenBao instances to read from.')}</p>
             </div>
             <Button type="button" variant="outline" size="sm" onclick={onAddVault}>
@@ -326,11 +343,6 @@
 
   /* Top bar */
   .adm-topbar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 1.5rem;
-    height: 3rem;
     border-bottom: 1px solid var(--vcv-color-border);
     background: var(--vcv-color-surface);
     flex-shrink: 0;
@@ -339,31 +351,9 @@
     z-index: 20;
   }
 
-  .adm-topbar-left {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.8125rem;
-  }
-
-  .adm-topbar-title {
-    font-weight: 600;
-    color: var(--vcv-color-text-strong);
-    letter-spacing: 0.01em;
-  }
-
-  .adm-topbar-sep {
-    color: var(--vcv-color-border-strong);
-  }
-
-  .adm-topbar-sub {
-    color: var(--vcv-color-muted);
-  }
-
-  .adm-topbar-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
+  .adm-topbar-bar {
+    padding: 0.625rem 1.5rem;
+    max-width: none;
   }
 
   .adm-action-link {
@@ -381,54 +371,6 @@
   .adm-action-link:hover {
     color: var(--vcv-color-text);
     background: var(--vcv-color-bg-hover);
-  }
-
-  .adm-action-btn {
-    padding: 0.25rem 0.75rem;
-    font-size: 0.75rem;
-    border-radius: var(--vcv-radius-sm);
-    cursor: pointer;
-    transition: background 0.12s, border-color 0.12s;
-  }
-
-  .adm-action-btn--secondary {
-    background: var(--vcv-color-surface);
-    border: 1px solid var(--vcv-color-border-strong);
-    color: var(--vcv-color-text);
-  }
-
-  .adm-action-btn--secondary:hover {
-    background: var(--vcv-color-bg-hover);
-  }
-
-  .adm-action-btn--ghost {
-    background: none;
-    border: 1px solid transparent;
-    color: var(--vcv-color-muted);
-  }
-
-  .adm-action-btn--ghost:hover {
-    color: var(--vcv-color-text);
-    background: var(--vcv-color-bg-hover);
-  }
-
-  /* Feedback */
-  .adm-feedback {
-    padding: 0.6rem 1.5rem;
-    font-size: 0.8125rem;
-    border-bottom: 1px solid;
-  }
-
-  .adm-feedback--error {
-    background: var(--vcv-color-danger-surface);
-    border-color: var(--vcv-color-danger-border);
-    color: var(--vcv-color-danger-text);
-  }
-
-  .adm-feedback--success {
-    background: var(--vcv-color-success-surface);
-    border-color: var(--vcv-color-success-border);
-    color: var(--vcv-color-success-text);
   }
 
   /* Body */
@@ -499,10 +441,18 @@
   }
 
   .adm-section-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     font-size: 0.875rem;
     font-weight: 600;
     color: var(--vcv-color-text-strong);
     margin: 0;
+  }
+
+  .adm-section-title :global(svg) {
+    color: var(--vcv-color-primary);
+    flex-shrink: 0;
   }
 
   .adm-section-hint {
@@ -576,9 +526,8 @@
     background: var(--vcv-color-bg-hover);
   }
 
-  .adm-toggle-input {
+  .adm-toggle :global(.tgl-switch) {
     margin-top: 0.1rem;
-    accent-color: var(--vcv-color-primary);
     flex-shrink: 0;
   }
 

--- a/app/web/frontend/src/lib/components/admin/ToggleSwitch.svelte
+++ b/app/web/frontend/src/lib/components/admin/ToggleSwitch.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  interface Props {
+    checked: boolean
+    onCheckedChange: (checked: boolean) => void
+    name?: string
+    disabled?: boolean
+  }
+
+  const { checked, onCheckedChange, name, disabled = false }: Props = $props()
+</script>
+
+<span class="tgl-switch">
+  <input
+    type="checkbox"
+    class="tgl-input"
+    {name}
+    {checked}
+    {disabled}
+    onchange={(event) => onCheckedChange((event.target as HTMLInputElement).checked)}
+  />
+  <span class="tgl-track" aria-hidden="true">
+    <span class="tgl-thumb"></span>
+  </span>
+</span>
+
+<style>
+  .tgl-switch {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    width: 2.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+  }
+
+  .tgl-input {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    opacity: 0;
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  .tgl-track {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: var(--vcv-color-border-strong);
+    border-radius: var(--vcv-radius-full);
+    transition: background-color 0.15s;
+  }
+
+  .tgl-thumb {
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    margin: 0.125rem;
+    background: var(--vcv-color-surface);
+    border-radius: 50%;
+    box-shadow: var(--vcv-shadow-button);
+    transition: transform 0.15s;
+  }
+
+  .tgl-input:checked + .tgl-track {
+    background: var(--vcv-color-primary);
+  }
+
+  .tgl-input:checked + .tgl-track .tgl-thumb {
+    transform: translateX(1rem);
+  }
+
+  .tgl-input:focus-visible + .tgl-track {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--vcv-color-focus-ring);
+  }
+
+  .tgl-input:disabled {
+    cursor: not-allowed;
+  }
+
+  .tgl-input:disabled + .tgl-track {
+    opacity: 0.6;
+  }
+</style>

--- a/app/web/frontend/src/lib/components/admin/VaultEditor.svelte
+++ b/app/web/frontend/src/lib/components/admin/VaultEditor.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+  import Server from '@lucide/svelte/icons/server'
+  import ChevronDown from '@lucide/svelte/icons/chevron-down'
   import { getI18n } from '$lib/stores/i18n.svelte'
+  import ToggleSwitch from './ToggleSwitch.svelte'
   import type { AdminVaultStatus, VaultInstance } from '$lib/types'
 
   interface Props {
@@ -75,6 +78,15 @@
     unknown: i18n.t('adminVaultUnknown', 'Unknown'),
   })
 
+  // Reuses the same badge classes CertStatusBadge applies to cert rows, so a
+  // vault's connection state reads with the exact same color language.
+  const statusBadgeClasses: Record<StatusKind, string> = {
+    connected: 'vcv-badge-valid',
+    disconnected: 'vcv-badge-critical',
+    disabled: 'vcv-badge-revoked',
+    unknown: 'vcv-badge-revoked',
+  }
+
   const kind = $derived(statusKind())
   const vaultLabel = $derived(vault.display_name || vault.id || i18n.t('adminVaultNew', 'new vault'))
 </script>
@@ -82,14 +94,17 @@
 <div class="ve-card" class:ve-card--collapsed={!expanded}>
   <!-- Summary row (always visible) -->
   <div class="ve-summary" role="button" tabindex="0" aria-expanded={expanded} aria-controls="ve-body-{uid}" onclick={toggleExpanded} onkeydown={onSummaryKeydown}>
-    <span class="ve-status-dot ve-status-dot--{kind}" title={statusLabels[kind]}></span>
+    <Server class="h-4 w-4 ve-summary-icon" aria-hidden="true" />
     <div class="ve-summary-info">
       <span class="ve-summary-id">{vaultLabel}</span>
       {#if vault.address}
         <span class="ve-summary-addr">{vault.address}</span>
       {/if}
     </div>
-    <span class="ve-status-label ve-status-label--{kind}">{statusLabels[kind]}</span>
+    <span class="vcv-badge {statusBadgeClasses[kind]} ve-status-badge">
+      <span class="ve-status-dot ve-status-dot--{kind}" aria-hidden="true"></span>
+      {statusLabels[kind]}
+    </span>
     <button
       type="button"
       class="ve-toggle-btn"
@@ -97,9 +112,7 @@
       onclick={onToggleClick}
       aria-label={expanded ? i18n.t('adminVaultCollapse', 'Collapse') : i18n.t('adminVaultExpand', 'Expand')}
     >
-      <svg class="ve-toggle-icon" class:ve-toggle-icon--open={expanded} viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M4 6l4 4 4-4"/>
-      </svg>
+      <ChevronDown class="ve-toggle-icon {expanded ? 've-toggle-icon--open' : ''}" aria-hidden="true" />
     </button>
   </div>
 
@@ -109,11 +122,10 @@
       <!-- Row: enabled toggle + remove -->
       <div class="ve-control-row">
         <label class="ve-enabled-toggle">
-          <input
-            type="checkbox"
+          <ToggleSwitch
             name="ve-enabled-{uid}"
             checked={enabled}
-            onchange={(event) => update('enabled', (event.target as HTMLInputElement).checked)}
+            onCheckedChange={(checked) => update('enabled', checked)}
           />
           <span>{i18n.t('adminVaultEnabled', 'Enabled')}</span>
         </label>
@@ -193,7 +205,10 @@
 
       <!-- TLS section -->
       <details class="ve-tls-details">
-        <summary class="ve-tls-summary">{i18n.t('adminVaultTLSOptions', 'TLS options')}</summary>
+        <summary class="ve-tls-summary">
+          {i18n.t('adminVaultTLSOptions', 'TLS options')}
+          <ChevronDown class="ve-tls-chevron" aria-hidden="true" />
+        </summary>
         <div class="ve-tls-body">
           <div class="ve-field">
             <label class="ve-label" for="ve-tls-ca-b64-{uid}">{i18n.t('adminVaultTLSCABase64', 'CA cert (base64)')}</label>
@@ -238,11 +253,10 @@
             />
           </div>
           <label class="ve-enabled-toggle">
-            <input
-              type="checkbox"
+            <ToggleSwitch
               name="ve-tls-insecure-{uid}"
               checked={vault.tls_insecure ?? false}
-              onchange={(event) => update('tls_insecure', (event.target as HTMLInputElement).checked)}
+              onCheckedChange={(checked) => update('tls_insecure', checked)}
             />
             <span>{i18n.t('adminVaultTLSInsecure', 'Skip TLS verification')}</span>
           </label>
@@ -302,47 +316,28 @@
     text-overflow: ellipsis;
   }
 
-  /* Status dot */
+  /* Server icon */
+  .ve-summary :global(.ve-summary-icon) {
+    color: var(--vcv-color-muted);
+    flex-shrink: 0;
+  }
+
+  /* Status dot (nested inside the badge) */
   .ve-status-dot {
-    width: 7px;
-    height: 7px;
+    width: 6px;
+    height: 6px;
     border-radius: 50%;
     flex-shrink: 0;
   }
 
-  .ve-status-dot--connected { background: var(--vcv-color-primary); }
-  .ve-status-dot--disconnected { background: var(--vcv-color-danger); }
-  .ve-status-dot--disabled { background: var(--vcv-color-muted); }
-  .ve-status-dot--unknown { background: var(--vcv-color-border-strong); }
+  .ve-status-dot--connected { background: var(--vcv-status-valid-text); }
+  .ve-status-dot--disconnected { background: var(--vcv-status-critical-text); }
+  .ve-status-dot--disabled { background: var(--vcv-status-revoked-text); }
+  .ve-status-dot--unknown { background: var(--vcv-color-muted); }
 
-  /* Status label */
-  .ve-status-label {
-    font-size: 0.7rem;
-    font-weight: 500;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    padding: 0.15rem 0.45rem;
-    border-radius: var(--vcv-radius-sm);
-  }
-
-  .ve-status-label--connected {
-    color: var(--vcv-color-success-text);
-    background: var(--vcv-color-success-surface);
-  }
-
-  .ve-status-label--disconnected {
-    color: var(--vcv-color-danger-text);
-    background: var(--vcv-color-danger-surface);
-  }
-
-  .ve-status-label--disabled {
-    color: var(--vcv-color-muted);
-    background: var(--vcv-color-surface-muted);
-  }
-
-  .ve-status-label--unknown {
-    color: var(--vcv-color-muted);
-    background: var(--vcv-color-surface-muted);
+  /* Status badge: color comes from the shared .vcv-badge-{tone} classes */
+  .ve-status-badge {
+    flex-shrink: 0;
   }
 
   /* Toggle button */
@@ -363,13 +358,13 @@
     background: var(--vcv-color-bg-hover);
   }
 
-  .ve-toggle-icon {
+  .ve-toggle-btn :global(.ve-toggle-icon) {
     width: 16px;
     height: 16px;
     transition: transform 0.18s ease-out;
   }
 
-  .ve-toggle-icon--open {
+  .ve-toggle-btn :global(.ve-toggle-icon--open) {
     transform: rotate(180deg);
   }
 
@@ -398,8 +393,8 @@
     cursor: pointer;
   }
 
-  .ve-enabled-toggle input {
-    accent-color: var(--vcv-color-primary);
+  .ve-enabled-toggle :global(.tgl-switch) {
+    flex-shrink: 0;
   }
 
   .ve-remove-btn {
@@ -499,6 +494,9 @@
   }
 
   .ve-tls-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     padding: 0.5rem 0.75rem;
     font-size: 0.75rem;
     font-weight: 500;
@@ -514,6 +512,17 @@
 
   .ve-tls-summary:hover {
     color: var(--vcv-color-text);
+  }
+
+  .ve-tls-summary :global(.ve-tls-chevron) {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    transition: transform 0.18s ease-out;
+  }
+
+  .ve-tls-details[open] .ve-tls-summary :global(.ve-tls-chevron) {
+    transform: rotate(180deg);
   }
 
   .ve-tls-body {

--- a/app/web/frontend/src/styles/vcv/17-responsive.css
+++ b/app/web/frontend/src/styles/vcv/17-responsive.css
@@ -88,6 +88,12 @@
   color: var(--vcv-status-warning-text);
 }
 
+.vcv-error-banner-success {
+  border: 1px solid var(--vcv-color-success-border);
+  background: var(--vcv-color-success-surface);
+  color: var(--vcv-color-success-text);
+}
+
 .vcv-error-banner-text {
   flex: 1;
 }


### PR DESCRIPTION
## Summary
- Admin panel was functional but visually generic (raw checkboxes, plain topbar, no icons, ad hoc CSS) and inconsistent with the main dashboard's `vcv-*` design system.
- Reskins the whole admin surface reusing existing tokens, classes, components, and icons — no new dependencies.

## Changes
- New `ToggleSwitch` component replaces raw checkboxes throughout (metrics, vault enabled, TLS-insecure)
- Topbar rebuilt with the same brand-mark/header-card treatment as the main dashboard; icon nav + section headers
- Feedback bar reuses the shared `ErrorBanner` component (added a `success` variant)
- Vault status pill reuses the app-wide `.vcv-badge-{tone}` classes instead of duplicating their colors
- Login screen gets an elevated card + the same brand mark as the main app header
- `AdminDocsModal` swapped raw shadcn tokens for `vcv-*` tokens

## Test plan
- [x] `pnpm check` (svelte-check + tsc) — 0 errors
- [x] `pnpm test` — 109/109 passing
- [x] `pnpm build` — succeeds
- [ ] Visual check in browser (light/dark, mobile width) once merged/deployed