### PR TITLE
docs(agents): clarify test coverage expectations and version injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ VCV_TAG=1.9 make docker-build
 ### Go
 
 - Prefer table-driven tests; use `_test` package for black-box when practical; name `Test<Func>_<Scenario>`.
+- Target high coverage (≥90%) for new or refactored packages; use `github.com/stretchr/testify/assert` and `testify/mock` for external boundaries (e.g. `vault.MockClient`).
 - Pass `context.Context` into Vault I/O and long-running work.
 - Match existing JSON error shapes in handlers (`error` field when clients expect it).
 - Prometheus: register on the **private** registry from `main` — not the global default registry.
@@ -356,7 +357,7 @@ When architecture or agent workflow drifts, update **AGENTS.md**. When handler/A
 - **`lint.yml`** — repo-wide linting
 - **`release.yml`** — on tag: GoReleaser `~> v2` builds frontend (pnpm), embeds dist, cross-compiles `vcv` (`./cmd/server`), publishes archives + Docker (`.goreleaser.yaml`)
 
-Release: push a semver tag (e.g. `1.9`); GoReleaser does the rest.
+Release: push a semver tag (e.g. `1.9`); GoReleaser does the rest. Only `version.Version` is injected via `-ldflags` (`-X vcv/internal/version.Version=...`); commit/build-time metadata is intentionally omitted.
 
 ## Agent habits for this repo
 


### PR DESCRIPTION
- Add explicit ≥90% coverage target for new/refactored Go packages
- Document testify/assert and testify/mock as standard tools
- Note that only version.Version is injected via ldflags; commit/build-time metadata intentionally omitted