### PR TITLE
feat(web): add expiry timeline component showing upcoming certificate…

### DIFF
--- a/app/internal/i18n/i18n.go
+++ b/app/internal/i18n/i18n.go
@@ -110,6 +110,10 @@ type Messages struct {
 	SortDirectionToggle         string `json:"sortDirectionToggle"`
 	SortByColumn                string `json:"sortByColumn"`
 	DashboardResultCount        string `json:"dashboardResultCount"`
+	ExpiryTimelineLabel         string `json:"expiryTimelineLabel"`
+	TimelineWithinDays          string `json:"timelineWithinDays"`
+	TimelineRangeDays           string `json:"timelineRangeDays"`
+	TimelineBeyondDays          string `json:"timelineBeyondDays"`
 	SearchPlaceholder           string `json:"searchPlaceholder"`
 	SearchShortcutHint          string `json:"searchShortcutHint"`
 	SelectAll                   string `json:"selectAll"`
@@ -325,6 +329,10 @@ var englishMessages = Messages{
 	SortDirectionToggle:            "Toggle sort direction",
 	SortByColumn:                   "Sort by {column}",
 	DashboardResultCount:           "{count} certificates",
+	ExpiryTimelineLabel:            "Upcoming expirations",
+	TimelineWithinDays:             "≤ {days} days",
+	TimelineRangeDays:              "{from}–{to} days",
+	TimelineBeyondDays:             "> {days} days",
 	SearchPlaceholder:              "Search by Serial Number, Common Name (CN) or SAN",
 	SelectAll:                      "Select all",
 	FilterChipSearch:               "Search",
@@ -529,6 +537,10 @@ var frenchMessages = Messages{
 	SortDirectionToggle:            "Inverser le sens du tri",
 	SortByColumn:                   "Trier par {column}",
 	DashboardResultCount:           "{count} certificats",
+	ExpiryTimelineLabel:            "Expirations à venir",
+	TimelineWithinDays:             "≤ {days} jours",
+	TimelineRangeDays:              "{from}–{to} jours",
+	TimelineBeyondDays:             "> {days} jours",
 	SearchPlaceholder:              "Rechercher par numéro de série, nom commun (CN) ou SAN",
 	SelectAll:                      "Tout sélectionner",
 	FilterChipSearch:               "Recherche",
@@ -733,6 +745,10 @@ var spanishMessages = Messages{
 	SortDirectionToggle:            "Invertir el sentido de orden",
 	SortByColumn:                   "Ordenar por {column}",
 	DashboardResultCount:           "{count} certificados",
+	ExpiryTimelineLabel:            "Próximos vencimientos",
+	TimelineWithinDays:             "≤ {days} días",
+	TimelineRangeDays:              "{from}–{to} días",
+	TimelineBeyondDays:             "> {days} días",
 	SearchPlaceholder:              "Buscar por Número de Serie, Nombre Común (CN) o SAN",
 	SelectAll:                      "Seleccionar todo",
 	FilterChipSearch:               "Search",
@@ -937,6 +953,10 @@ var germanMessages = Messages{
 	SortDirectionToggle:            "Sortierrichtung umschalten",
 	SortByColumn:                   "Sortieren nach {column}",
 	DashboardResultCount:           "{count} Zertifikate",
+	ExpiryTimelineLabel:            "Bevorstehende Abläufe",
+	TimelineWithinDays:             "≤ {days} Tage",
+	TimelineRangeDays:              "{from}–{to} Tage",
+	TimelineBeyondDays:             "> {days} Tage",
 	SearchPlaceholder:              "Suche nach Seriennummer, Common Name (CN) oder SAN",
 	SelectAll:                      "Alle auswählen",
 	FilterChipSearch:               "Search",
@@ -1141,6 +1161,10 @@ var italianMessages = Messages{
 	SortDirectionToggle:            "Inverti la direzione di ordinamento",
 	SortByColumn:                   "Ordina per {column}",
 	DashboardResultCount:           "{count} certificati",
+	ExpiryTimelineLabel:            "Scadenze imminenti",
+	TimelineWithinDays:             "≤ {days} giorni",
+	TimelineRangeDays:              "{from}–{to} giorni",
+	TimelineBeyondDays:             "> {days} giorni",
 	SearchPlaceholder:              "Cerca per Numero di Serie, Nome Comune (CN) o SAN",
 	SelectAll:                      "Seleziona tutto",
 	FilterChipSearch:               "Search",

--- a/app/web/frontend/src/App.svelte
+++ b/app/web/frontend/src/App.svelte
@@ -14,6 +14,7 @@
   import FilterBar from '$lib/components/FilterBar.svelte'
   import MountSelectorDialog from '$lib/components/MountSelectorDialog.svelte'
   import StatusOverview from '$lib/components/StatusOverview.svelte'
+  import ExpiryTimeline from '$lib/components/ExpiryTimeline.svelte'
   import CertTable from '$lib/components/CertTable.svelte'
   import CertMobileList from '$lib/components/CertMobileList.svelte'
   import PaginationBar from '$lib/components/PaginationBar.svelte'
@@ -548,6 +549,8 @@
       regionLabel={i18n.t('dashboardOverviewLabel', 'Certificate status overview')}
       onSelect={toggleStatus}
     />
+
+    <ExpiryTimeline certs={certs.certificates} {thresholds} />
 
     <div class="vcv-results-bar">
       <span class="vcv-results-count" aria-live="polite">{resultCountText}</span>

--- a/app/web/frontend/src/lib/components/ExpiryTimeline.svelte
+++ b/app/web/frontend/src/lib/components/ExpiryTimeline.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { getI18n } from '$lib/stores/i18n.svelte'
+  import { buildExpiryTimeline, type ExpiryBucket } from '$lib/utils/expiry-timeline'
+  import type { Certificate, ExpirationThresholds } from '$lib/types'
+
+  interface Props {
+    certs: Certificate[]
+    thresholds: ExpirationThresholds
+  }
+
+  const { certs, thresholds }: Props = $props()
+  const i18n = getI18n()
+
+  const buckets = $derived(buildExpiryTimeline(certs, thresholds))
+  const total = $derived(buckets.reduce((sum, bucket) => sum + bucket.count, 0))
+
+  function bucketLabel(bucket: ExpiryBucket): string {
+    if (bucket.key === 'critical') {
+      return i18n.t('timelineWithinDays', '≤ {days} days', { days: bucket.to ?? 0 })
+    }
+    if (bucket.key === 'later') {
+      return i18n.t('timelineBeyondDays', '> {days} days', { days: bucket.from - 1 })
+    }
+    return i18n.t('timelineRangeDays', '{from}–{to} days', { from: bucket.from, to: bucket.to ?? 0 })
+  }
+</script>
+
+{#if total > 0}
+  <section class="vcv-expiry-timeline" aria-label={i18n.t('expiryTimelineLabel', 'Upcoming expirations')}>
+    <span class="vcv-expiry-timeline-title">{i18n.t('expiryTimelineLabel', 'Upcoming expirations')}</span>
+    <div class="vcv-expiry-timeline-buckets">
+      {#each buckets as bucket (bucket.key)}
+        <div class="vcv-expiry-bucket vcv-expiry-bucket-{bucket.tone}">
+          <span class="vcv-expiry-bucket-count">{bucket.count}</span>
+          <span class="vcv-expiry-bucket-label">{bucketLabel(bucket)}</span>
+        </div>
+      {/each}
+    </div>
+  </section>
+{/if}

--- a/app/web/frontend/src/lib/components/ExpiryTimeline.test.ts
+++ b/app/web/frontend/src/lib/components/ExpiryTimeline.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/svelte'
+import type { Certificate } from '$lib/types'
+
+vi.mock('$lib/stores/i18n.svelte', () => ({
+  getI18n: () => ({
+    t: (_key: string, fallback?: string, params?: Record<string, string | number>) =>
+      Object.entries(params ?? {}).reduce(
+        (acc, [name, value]) => acc.replaceAll(`{${name}}`, String(value)),
+        fallback ?? _key,
+      ),
+  }),
+}))
+
+import ExpiryTimeline from '$lib/components/ExpiryTimeline.svelte'
+
+const thresholds = { critical: 7, warning: 30 }
+
+function cert(overrides: Partial<Certificate> = {}): Certificate {
+  return {
+    id: 'v|m:1',
+    serialNumber: 'aa:bb',
+    commonName: 'web.example.com',
+    sans: [],
+    certType: 'machine',
+    createdAt: '2024-01-01T00:00:00Z',
+    expiresAt: new Date(Date.now() + 3.5 * 86_400_000).toISOString(),
+    revoked: false,
+    ...overrides,
+  }
+}
+
+describe('ExpiryTimeline', () => {
+  it('renders bucket counts and threshold-aware labels', () => {
+    render(ExpiryTimeline, { props: { certs: [cert()], thresholds } })
+
+    const region = screen.getByRole('region', { name: 'Upcoming expirations' })
+    expect(region).toBeInTheDocument()
+    expect(region.textContent).toContain('≤ 7 days')
+    expect(region.textContent).toContain('8–30 days')
+    expect(region.textContent).toContain('31–90 days')
+    expect(region.textContent).toContain('> 90 days')
+    // One cert expiring in ~3 days shows up in the critical bucket.
+    const criticalBucket = region.querySelector('.vcv-expiry-bucket-critical .vcv-expiry-bucket-count')
+    expect(criticalBucket?.textContent).toBe('1')
+  })
+
+  it('renders nothing when no certificate expires in the future', () => {
+    const { container } = render(ExpiryTimeline, {
+      props: { certs: [cert({ revoked: true })], thresholds },
+    })
+
+    expect(container.querySelector('.vcv-expiry-timeline')).toBeNull()
+  })
+})

--- a/app/web/frontend/src/lib/utils/expiry-timeline.test.ts
+++ b/app/web/frontend/src/lib/utils/expiry-timeline.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { buildExpiryTimeline, TIMELINE_FAR_HORIZON_DAYS, type ExpiryBucket } from '$lib/utils/expiry-timeline'
+import { DEFAULT_THRESHOLDS } from '$lib/utils/cert-status'
+import type { Certificate, ExpirationThresholds } from '$lib/types'
+
+const NOW = new Date('2026-07-31T12:00:00Z')
+
+function cert(overrides: Partial<Certificate> = {}): Certificate {
+  return {
+    id: 'v|m:1',
+    serialNumber: 'aa:bb',
+    commonName: 'web.example.com',
+    sans: [],
+    certType: 'machine',
+    createdAt: '2024-01-01T00:00:00Z',
+    expiresAt: '2999-01-01T00:00:00Z',
+    revoked: false,
+    ...overrides,
+  }
+}
+
+function expiresInDays(days: number): string {
+  return new Date(NOW.getTime() + days * 86_400_000).toISOString()
+}
+
+function counts(buckets: ExpiryBucket[]): Record<string, number> {
+  const all: Record<string, number> = { critical: 0, warning: 0, near: 0, later: 0 }
+  for (const bucket of buckets) {
+    all[bucket.key] = bucket.count
+  }
+  return all
+}
+
+describe('buildExpiryTimeline', () => {
+  const thresholds: ExpirationThresholds = DEFAULT_THRESHOLDS // critical 7, warning 30
+
+  const cases: { name: string; certs: Certificate[]; expected: Record<string, number> }[] = [
+    {
+      name: 'cert expiring within the critical threshold lands in critical',
+      certs: [cert({ expiresAt: expiresInDays(3.5) })],
+      expected: { critical: 1, warning: 0, near: 0, later: 0 },
+    },
+    {
+      name: 'cert expiring today counts as critical, not expired',
+      certs: [cert({ expiresAt: expiresInDays(0.5) })],
+      expected: { critical: 1, warning: 0, near: 0, later: 0 },
+    },
+    {
+      name: 'cert between thresholds lands in warning',
+      certs: [cert({ expiresAt: expiresInDays(20.5) })],
+      expected: { critical: 0, warning: 1, near: 0, later: 0 },
+    },
+    {
+      name: 'cert past the warning threshold lands in near',
+      certs: [cert({ expiresAt: expiresInDays(60.5) })],
+      expected: { critical: 0, warning: 0, near: 1, later: 0 },
+    },
+    {
+      name: 'cert past the far horizon lands in later',
+      certs: [cert({ expiresAt: expiresInDays(200.5) })],
+      expected: { critical: 0, warning: 0, near: 0, later: 1 },
+    },
+    {
+      name: 'already expired certs are excluded',
+      certs: [cert({ expiresAt: expiresInDays(-2.5) })],
+      expected: { critical: 0, warning: 0, near: 0, later: 0 },
+    },
+    {
+      name: 'revoked certs are excluded',
+      certs: [cert({ expiresAt: expiresInDays(3.5), revoked: true })],
+      expected: { critical: 0, warning: 0, near: 0, later: 0 },
+    },
+    {
+      name: 'unparseable expiry dates are excluded',
+      certs: [cert({ expiresAt: 'not-a-date' })],
+      expected: { critical: 0, warning: 0, near: 0, later: 0 },
+    },
+  ]
+
+  for (const { name, certs, expected } of cases) {
+    it(name, () => {
+      expect(counts(buildExpiryTimeline(certs, thresholds, NOW))).toEqual(expected)
+    })
+  }
+
+  it('respects custom thresholds for the critical/warning boundary', () => {
+    const custom: ExpirationThresholds = { critical: 14, warning: 45 }
+    const buckets = buildExpiryTimeline([cert({ expiresAt: expiresInDays(10.5) })], custom, NOW)
+    expect(counts(buckets)).toEqual({ critical: 1, warning: 0, near: 0, later: 0 })
+    expect(buckets[0]).toMatchObject({ key: 'critical', from: 0, to: 14 })
+    expect(buckets[1]).toMatchObject({ key: 'warning', from: 15, to: 45 })
+  })
+
+  it('drops the near bucket when the warning threshold reaches the far horizon', () => {
+    const wide: ExpirationThresholds = { critical: 7, warning: TIMELINE_FAR_HORIZON_DAYS + 10 }
+    const buckets = buildExpiryTimeline([cert({ expiresAt: expiresInDays(200.5) })], wide, NOW)
+    expect(buckets.map((bucket) => bucket.key)).toEqual(['critical', 'warning', 'later'])
+    expect(buckets.at(-1)).toMatchObject({ key: 'later', from: TIMELINE_FAR_HORIZON_DAYS + 11, to: null, count: 1 })
+  })
+
+  it('collapses the warning bucket when warning is less than or equal to critical', () => {
+    const inverted: ExpirationThresholds = { critical: 30, warning: 7 }
+    const close = buildExpiryTimeline([cert({ expiresAt: expiresInDays(20.5) })], inverted, NOW)
+    expect(counts(close)).toEqual({ critical: 1, warning: 0, near: 0, later: 0 })
+    const far = buildExpiryTimeline([cert({ expiresAt: expiresInDays(45.5) })], inverted, NOW)
+    expect(counts(far)).toEqual({ critical: 0, warning: 0, near: 1, later: 0 })
+    expect(far.map((bucket) => bucket.key)).toEqual(['critical', 'near', 'later'])
+  })
+})

--- a/app/web/frontend/src/lib/utils/expiry-timeline.ts
+++ b/app/web/frontend/src/lib/utils/expiry-timeline.ts
@@ -1,0 +1,64 @@
+import { daysUntilExpiry } from '$lib/utils/cert-status'
+import type { Certificate, ExpirationThresholds } from '$lib/types'
+
+/** Upper edge of the "near" bucket; beyond this certs sit in the open-ended "later" bucket. */
+export const TIMELINE_FAR_HORIZON_DAYS = 90
+
+export type ExpiryBucketKey = 'critical' | 'warning' | 'near' | 'later'
+export type ExpiryBucketTone = 'critical' | 'warning' | 'neutral' | 'muted'
+
+export interface ExpiryBucket {
+  key: ExpiryBucketKey
+  /** Inclusive lower bound in days from now. */
+  from: number
+  /** Inclusive upper bound in days from now; null when open-ended. */
+  to: number | null
+  count: number
+  tone: ExpiryBucketTone
+}
+
+/**
+ * Bucket not-yet-expired, non-revoked certificates by time-to-expiry.
+ * The first two buckets follow the configured critical/warning thresholds;
+ * certificates already expired or with an unparseable expiry are excluded
+ * (they are covered by the status overview, not a future timeline).
+ */
+export function buildExpiryTimeline(
+  certs: Certificate[],
+  thresholds: ExpirationThresholds,
+  now: Date = new Date(),
+): ExpiryBucket[] {
+  const critical = thresholds.critical
+  const warning = Math.max(critical, thresholds.warning)
+
+  const buckets: ExpiryBucket[] = [
+    { key: 'critical', from: 0, to: critical, count: 0, tone: 'critical' },
+  ]
+
+  // The warning bucket only makes sense when it is wider than the critical bucket.
+  if (warning > critical) {
+    buckets.push({ key: 'warning', from: critical + 1, to: warning, count: 0, tone: 'warning' })
+  }
+
+  // The near bucket only exists when the warning threshold leaves room before the far horizon.
+  if (warning < TIMELINE_FAR_HORIZON_DAYS) {
+    buckets.push({ key: 'near', from: warning + 1, to: TIMELINE_FAR_HORIZON_DAYS, count: 0, tone: 'neutral' })
+  }
+
+  buckets.push({
+    key: 'later',
+    from: Math.max(warning, TIMELINE_FAR_HORIZON_DAYS) + 1,
+    to: null,
+    count: 0,
+    tone: 'muted',
+  })
+
+  for (const cert of certs) {
+    if (cert.revoked) continue
+    const days = daysUntilExpiry(cert, now)
+    if (!Number.isFinite(days) || days < 0) continue
+    const bucket = buckets.find((candidate) => days >= candidate.from && (candidate.to === null || days <= candidate.to))
+    if (bucket) bucket.count++
+  }
+  return buckets
+}

--- a/app/web/frontend/src/styles/vcv/14-overview.css
+++ b/app/web/frontend/src/styles/vcv/14-overview.css
@@ -208,6 +208,87 @@
   font-style: italic;
 }
 
+/* Expiry timeline: upcoming expirations bucketed by time-to-expiry */
+.vcv-expiry-timeline {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  padding: 0.625rem 1.25rem;
+  border: 1px solid var(--vcv-color-border);
+  border-radius: var(--vcv-radius-lg);
+  background: var(--vcv-color-surface);
+  box-shadow: var(--vcv-shadow-card);
+}
+
+.vcv-expiry-timeline-title {
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vcv-color-muted);
+  white-space: nowrap;
+}
+
+.vcv-expiry-timeline-buckets {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  gap: 0.5rem;
+}
+
+.vcv-expiry-bucket {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--vcv-radius-sm);
+  background: var(--vcv-color-surface-muted);
+}
+
+.vcv-expiry-bucket-count {
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--vcv-color-text-strong);
+}
+
+.vcv-expiry-bucket-label {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--vcv-color-muted);
+  white-space: nowrap;
+}
+
+.vcv-expiry-bucket-critical .vcv-expiry-bucket-count {
+  color: var(--vcv-color-danger);
+}
+
+.vcv-expiry-bucket-warning .vcv-expiry-bucket-count {
+  color: var(--vcv-color-warning-strong);
+}
+
+@media (900px >= width) {
+  .vcv-expiry-timeline {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    padding: 0.625rem 1rem;
+  }
+
+  .vcv-expiry-timeline-buckets {
+    flex-wrap: wrap;
+  }
+
+  .vcv-expiry-bucket {
+    min-width: 8rem;
+  }
+}
+
 .vcv-status-indicator {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
… expirations

- Add ExpiryTimeline component displaying certificate counts bucketed by time-to-expiry (critical/warning/near/later)
- Implement buildExpiryTimeline utility with threshold-aware bucket logic and 90-day far horizon
- Add i18n keys (ExpiryTimelineLabel, TimelineWithinDays, TimelineRangeDays, TimelineBeyondDays) in all five languages
- Render timeline above results bar in App.svelte when certificates exist