### PR TITLE
fix(backend): resolve SonarQube Go findings (S3776, S1192, S1186, S107)

### DIFF
--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -103,9 +103,23 @@ func newStatusHandler(cfg config.Config, primaryVaultClient vault.Client, status
 	}
 }
 
-func buildRouter(cfg config.Config, primaryVaultClient vault.Client, statusClients map[string]vault.Client, multiVaultClient vault.Client, registry *prometheus.Registry, webFS fs.FS, settingsPath string, vaultRegistry *vault.Registry) (*chi.Mux, error) {
+// routerDeps bundles the collaborators buildRouter needs, keeping the
+// function signature within the parameter limit.
+type routerDeps struct {
+	cfg           config.Config
+	primaryVault  vault.Client
+	statusClients map[string]vault.Client
+	multiVault    vault.Client
+	vaultRegistry *vault.Registry
+	promRegistry  *prometheus.Registry
+	webFS         fs.FS
+	settingsPath  string
+}
+
+func buildRouter(deps routerDeps) (*chi.Mux, error) {
+	cfg := deps.cfg
 	r := chi.NewRouter()
-	distFS, distError := fs.Sub(webFS, "dist")
+	distFS, distError := fs.Sub(deps.webFS, "dist")
 	if distError != nil {
 		return nil, distError
 	}
@@ -136,16 +150,16 @@ func buildRouter(cfg config.Config, primaryVaultClient vault.Client, statusClien
 	r.Get("/api/health", handlers.HealthCheck)
 	r.Get("/api/ready", handlers.ReadinessCheck)
 	// Admin is optional; process stays up. Surface enablement on /api/status (not fail-ready).
-	adminAPIEnabled := handlers.RegisterAdminRoutes(r, settingsPath, cfg.Env, vaultRegistry, statusClients, multiVaultClient, cfg.TrustProxy)
-	r.Get("/api/status", newStatusHandler(cfg, primaryVaultClient, statusClients, adminAPIEnabled))
+	adminAPIEnabled := handlers.RegisterAdminRoutes(r, deps.settingsPath, cfg.Env, deps.vaultRegistry, deps.statusClients, deps.multiVault, cfg.TrustProxy)
+	r.Get("/api/status", newStatusHandler(cfg, deps.primaryVault, deps.statusClients, adminAPIEnabled))
 	r.Get("/api/version", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(version.Info())
 	})
-	r.Get("/api/config", handlers.GetConfig(cfg, vaultRegistry))
-	r.Get("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP)
+	r.Get("/api/config", handlers.GetConfig(cfg, deps.vaultRegistry))
+	r.Get("/metrics", promhttp.HandlerFor(deps.promRegistry, promhttp.HandlerOpts{}).ServeHTTP)
 	handlers.RegisterI18nRoutes(r)
-	handlers.RegisterCertRoutes(r, multiVaultClient)
+	handlers.RegisterCertRoutes(r, deps.multiVault)
 
 	return r, nil
 }
@@ -222,7 +236,16 @@ func main() {
 		Str("settings_path", settingsPath).
 		Msg("Using admin settings file")
 
-	router, buildErr := buildRouter(cfg, primaryVaultClient, allClients, multiVaultClient, promRegistry, webFS, settingsPath, vaultRegistry)
+	router, buildErr := buildRouter(routerDeps{
+		cfg:           cfg,
+		primaryVault:  primaryVaultClient,
+		statusClients: allClients,
+		multiVault:    multiVaultClient,
+		vaultRegistry: vaultRegistry,
+		promRegistry:  promRegistry,
+		webFS:         webFS,
+		settingsPath:  settingsPath,
+	})
 	if buildErr != nil {
 		log.Fatal().Err(buildErr).
 			Msg("Failed to initialize router")

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -47,57 +47,68 @@ func publicVaultStatusError(err error) string {
 	return "vault unavailable"
 }
 
+// vaultStatusEntry is the per-vault section of the /api/status response.
+type vaultStatusEntry struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	Connected   bool   `json:"connected"`
+	Error       string `json:"error,omitempty"`
+}
+
+// statusResponse is the /api/status payload.
+type statusResponse struct {
+	Version         string             `json:"version"`
+	VaultConnected  bool               `json:"vault_connected"`
+	VaultError      string             `json:"vault_error,omitempty"`
+	AdminAPIEnabled bool               `json:"admin_api_enabled"`
+	Vaults          []vaultStatusEntry `json:"vaults"`
+}
+
+// checkPrimaryVault checks the legacy primary connection in parallel-friendly
+// form and maps failures to a sanitized error string.
+func checkPrimaryVault(ctx context.Context, client vault.Client) (bool, string) {
+	results := vault.CheckInstances(ctx, []string{"primary"}, map[string]vault.Client{"primary": client}, 5*time.Second)
+	var primaryErr error
+	if len(results) > 0 {
+		if results[0].Connected {
+			return true, ""
+		}
+		primaryErr = results[0].Error
+	}
+	return false, publicVaultStatusError(primaryErr)
+}
+
+// appendVaultStatuses checks each configured vault and appends status entries.
+func appendVaultStatuses(ctx context.Context, response *statusResponse, instances []config.VaultInstance, clients map[string]vault.Client) {
+	ordered := make([]string, 0, len(instances))
+	displayNames := make(map[string]string, len(instances))
+	for _, instance := range instances {
+		ordered = append(ordered, instance.ID)
+		displayNames[instance.ID] = instance.DisplayName
+	}
+	if clients == nil {
+		clients = map[string]vault.Client{}
+	}
+	checked := vault.CheckInstances(ctx, ordered, clients, 5*time.Second)
+	for _, item := range checked {
+		entry := vaultStatusEntry{ID: item.ID, DisplayName: displayNames[item.ID], Connected: item.Connected}
+		if _, ok := clients[item.ID]; !ok || clients[item.ID] == nil {
+			entry.Connected = false
+			entry.Error = "missing vault status client"
+		} else if !item.Connected {
+			entry.Error = publicVaultStatusError(item.Error)
+		}
+		response.Vaults = append(response.Vaults, entry)
+	}
+}
+
 func newStatusHandler(cfg config.Config, primaryVaultClient vault.Client, statusClients map[string]vault.Client, adminAPIEnabled bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		type vaultStatusEntry struct {
-			ID          string `json:"id"`
-			DisplayName string `json:"display_name"`
-			Connected   bool   `json:"connected"`
-			Error       string `json:"error,omitempty"`
-		}
-		type statusResponse struct {
-			Version         string             `json:"version"`
-			VaultConnected  bool               `json:"vault_connected"`
-			VaultError      string             `json:"vault_error,omitempty"`
-			AdminAPIEnabled bool               `json:"admin_api_enabled"`
-			Vaults          []vaultStatusEntry `json:"vaults"`
-		}
 		response := statusResponse{Version: version.Version, AdminAPIEnabled: adminAPIEnabled, Vaults: make([]vaultStatusEntry, 0, len(cfg.Vaults))}
-		// Primary connection (historical field) checked in parallel with per-vault checks via helper.
-		primaryClients := map[string]vault.Client{"primary": primaryVaultClient}
-		primaryResults := vault.CheckInstances(ctx, []string{"primary"}, primaryClients, 5*time.Second)
-		if len(primaryResults) > 0 && primaryResults[0].Connected {
-			response.VaultConnected = true
-		} else {
-			response.VaultConnected = false
-			var primaryErr error
-			if len(primaryResults) > 0 {
-				primaryErr = primaryResults[0].Error
-			}
-			response.VaultError = publicVaultStatusError(primaryErr)
-		}
-		ordered := make([]string, 0, len(cfg.Vaults))
-		displayNames := make(map[string]string, len(cfg.Vaults))
-		for _, instance := range cfg.Vaults {
-			ordered = append(ordered, instance.ID)
-			displayNames[instance.ID] = instance.DisplayName
-		}
-		clients := statusClients
-		if clients == nil {
-			clients = map[string]vault.Client{}
-		}
-		checked := vault.CheckInstances(ctx, ordered, clients, 5*time.Second)
-		for _, item := range checked {
-			entry := vaultStatusEntry{ID: item.ID, DisplayName: displayNames[item.ID], Connected: item.Connected}
-			if _, ok := clients[item.ID]; !ok || clients[item.ID] == nil {
-				entry.Connected = false
-				entry.Error = "missing vault status client"
-			} else if !item.Connected {
-				entry.Error = publicVaultStatusError(item.Error)
-			}
-			response.Vaults = append(response.Vaults, entry)
-		}
+		// Primary connection (historical field) checked via helper.
+		response.VaultConnected, response.VaultError = checkPrimaryVault(ctx, primaryVaultClient)
+		appendVaultStatuses(ctx, &response, cfg.Vaults, statusClients)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(response)
 	}
@@ -164,28 +175,11 @@ func buildRouter(deps routerDeps) (*chi.Mux, error) {
 	return r, nil
 }
 
-func main() {
-	cfg, cfgErr := config.Load()
-	if cfgErr != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load configuration: %v\n", cfgErr)
-		os.Exit(1)
-	}
-
-	// Initialize structured logger from config
-	logger.Init(cfg.LogLevel)
-	log := logger.Get()
-
-	log.Info().
-		Str("version", version.Version).
-		Msg("VaultCertsViewer starting")
-
-	log.Info().
-		Str("env", string(cfg.Env)).
-		Str("log_level", cfg.LogLevel).
-		Str("log_format", cfg.LogFormat).
-		Msg("Configuration loaded")
-	// Create clients for ALL vaults (including disabled) so they can be
-	// toggled at runtime via the admin panel without a restart.
+// initVaultClients creates clients for ALL vaults (including disabled) so
+// they can be toggled at runtime via the admin panel without a restart, and
+// returns them plus the primary client. Sets cfg.Vault to the primary
+// instance's config for logging/legacy use.
+func initVaultClients(cfg *config.Config, log *logger.Logger) (map[string]vault.Client, vault.Client) {
 	allClients := make(map[string]vault.Client, len(cfg.AllVaults))
 	var primaryVaultClient vault.Client
 	for i, instance := range cfg.AllVaults {
@@ -209,6 +203,44 @@ func main() {
 	if primaryVaultClient == nil {
 		primaryVaultClient = vault.NewDisabledClient()
 	}
+	return allClients, primaryVaultClient
+}
+
+// shutdownVaultClients shuts down each unique client once.
+func shutdownVaultClients(allClients map[string]vault.Client) {
+	uniqueClients := make(map[vault.Client]struct{})
+	for _, client := range allClients {
+		if client == nil {
+			continue
+		}
+		uniqueClients[client] = struct{}{}
+	}
+	for client := range uniqueClients {
+		client.Shutdown()
+	}
+}
+
+func main() {
+	cfg, cfgErr := config.Load()
+	if cfgErr != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load configuration: %v\n", cfgErr)
+		os.Exit(1)
+	}
+
+	// Initialize structured logger from config
+	logger.Init(cfg.LogLevel)
+	log := logger.Get()
+
+	log.Info().
+		Str("version", version.Version).
+		Msg("VaultCertsViewer starting")
+
+	log.Info().
+		Str("env", string(cfg.Env)).
+		Str("log_level", cfg.LogLevel).
+		Str("log_format", cfg.LogFormat).
+		Msg("Configuration loaded")
+	allClients, primaryVaultClient := initVaultClients(&cfg, log)
 
 	vaultRegistry := vault.NewRegistry(cfg.AllVaults)
 	multiVaultClient := vault.NewMultiClient(cfg.AllVaults, allClients, vaultRegistry)
@@ -299,16 +331,7 @@ func main() {
 		log.Fatal().Err(err).Msg("Server forced to shutdown")
 	}
 
-	uniqueClients := make(map[vault.Client]struct{})
-	for _, client := range allClients {
-		if client == nil {
-			continue
-		}
-		uniqueClients[client] = struct{}{}
-	}
-	for client := range uniqueClients {
-		client.Shutdown()
-	}
+	shutdownVaultClients(allClients)
 
 	log.Info().Msg("Server stopped")
 }

--- a/app/cmd/server/main_test.go
+++ b/app/cmd/server/main_test.go
@@ -126,7 +126,7 @@ func TestBuildRouter_Dev(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	vaultRegistry := vault.NewRegistry(cfg.Vaults)
 
-	router, err := buildRouter(cfg, primary, map[string]vault.Client{"v1": primary}, multi, registry, webFS, "/tmp/settings.json", vaultRegistry)
+	router, err := buildRouter(routerDeps{cfg: cfg, primaryVault: primary, statusClients: map[string]vault.Client{"v1": primary}, multiVault: multi, vaultRegistry: vaultRegistry, promRegistry: registry, webFS: webFS, settingsPath: "/tmp/settings.json"})
 	require.NoError(t, err)
 	assert.NotNil(t, router)
 
@@ -152,7 +152,7 @@ func TestBuildRouter_Prod(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	vaultRegistry := vault.NewRegistry(cfg.Vaults)
 
-	router, err := buildRouter(cfg, primary, map[string]vault.Client{}, multi, registry, webFS, "/tmp/settings.json", vaultRegistry)
+	router, err := buildRouter(routerDeps{cfg: cfg, primaryVault: primary, statusClients: map[string]vault.Client{}, multiVault: multi, vaultRegistry: vaultRegistry, promRegistry: registry, webFS: webFS, settingsPath: "/tmp/settings.json"})
 	require.NoError(t, err)
 	assert.NotNil(t, router)
 }
@@ -169,7 +169,7 @@ func TestBuildRouter_MissingDist(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	vaultRegistry := vault.NewRegistry(nil)
 
-	_, err := buildRouter(cfg, primary, nil, multi, registry, errFS{}, "/tmp/settings.json", vaultRegistry)
+	_, err := buildRouter(routerDeps{cfg: cfg, primaryVault: primary, statusClients: nil, multiVault: multi, vaultRegistry: vaultRegistry, promRegistry: registry, webFS: errFS{}, settingsPath: "/tmp/settings.json"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no dist dir")
 }
@@ -189,7 +189,7 @@ func TestBuildRouter_Routes(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	vaultRegistry := vault.NewRegistry(cfg.Vaults)
 
-	router, err := buildRouter(cfg, primary, map[string]vault.Client{}, multi, registry, webFS, "/tmp/settings.json", vaultRegistry)
+	router, err := buildRouter(routerDeps{cfg: cfg, primaryVault: primary, statusClients: map[string]vault.Client{}, multiVault: multi, vaultRegistry: vaultRegistry, promRegistry: registry, webFS: webFS, settingsPath: "/tmp/settings.json"})
 	require.NoError(t, err)
 
 	// Test /api/version

--- a/app/cmd/server/router_test.go
+++ b/app/cmd/server/router_test.go
@@ -49,7 +49,7 @@ func TestBuildRouter_BasicEndpoints(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	webFS := newServerWebFS()
 	statusClients := map[string]vault.Client{}
-	router, err := buildRouter(cfg, primary, statusClients, multi, registry, webFS, "", nil)
+	router, err := buildRouter(routerDeps{cfg: cfg, primaryVault: primary, statusClients: statusClients, multiVault: multi, promRegistry: registry, webFS: webFS})
 	assert.NoError(t, err)
 
 	t.Run("serves index", func(t *testing.T) {
@@ -143,7 +143,7 @@ func TestBuildRouter_MissingAssets_Returns404(t *testing.T) {
 	webFS := fstest.MapFS{
 		"dist/index.html": &fstest.MapFile{Data: []byte("ok")},
 	}
-	router, err := buildRouter(cfg, primary, map[string]vault.Client{}, multi, registry, webFS, "", nil)
+	router, err := buildRouter(routerDeps{cfg: cfg, primaryVault: primary, statusClients: map[string]vault.Client{}, multiVault: multi, promRegistry: registry, webFS: webFS})
 	assert.NotNil(t, router)
 	assert.NoError(t, err)
 	req := httptest.NewRequest(http.MethodGet, "/assets/missing.js", nil)
@@ -160,7 +160,7 @@ func TestBuildRouter_MissingIndex_Returns404(t *testing.T) {
 	webFS := fstest.MapFS{
 		"dist/assets/app.js": &fstest.MapFile{Data: []byte("console.log('ok')")},
 	}
-	router, err := buildRouter(cfg, primary, map[string]vault.Client{}, multi, registry, webFS, "", nil)
+	router, err := buildRouter(routerDeps{cfg: cfg, primaryVault: primary, statusClients: map[string]vault.Client{}, multiVault: multi, promRegistry: registry, webFS: webFS})
 	assert.NoError(t, err)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()

--- a/app/cmd/server/status_handler_test.go
+++ b/app/cmd/server/status_handler_test.go
@@ -14,19 +14,6 @@ import (
 	"vcv/internal/vault"
 )
 
-type statusResponse struct {
-	Version         string `json:"version"`
-	VaultConnected  bool   `json:"vault_connected"`
-	VaultError      string `json:"vault_error,omitempty"`
-	AdminAPIEnabled bool   `json:"admin_api_enabled"`
-	Vaults          []struct {
-		ID          string `json:"id"`
-		DisplayName string `json:"display_name"`
-		Connected   bool   `json:"connected"`
-		Error       string `json:"error,omitempty"`
-	} `json:"vaults"`
-}
-
 func TestNewStatusHandler_PrimaryDisconnectedAndMissingClient(t *testing.T) {
 	cfg := config.Config{Vaults: []config.VaultInstance{{ID: "v1", DisplayName: "Vault 1"}}}
 	primary := &vault.MockClient{}

--- a/app/internal/config/config_test.go
+++ b/app/internal/config/config_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadDefaults(t *testing.T) {
@@ -106,49 +109,21 @@ func TestLoadFromSettingsFile(t *testing.T) {
 	}
 
 	cfg, err := Load()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if cfg.Env != EnvProd {
-		t.Fatalf("expected prod env, got %s", cfg.Env)
-	}
-	if cfg.Port != "1234" {
-		t.Fatalf("expected port 1234, got %s", cfg.Port)
-	}
-	if cfg.LogLevel != "warn" {
-		t.Fatalf("expected log level warn, got %s", cfg.LogLevel)
-	}
-	if cfg.LogFormat != "json" {
-		t.Fatalf("expected log format json, got %s", cfg.LogFormat)
-	}
-	if len(cfg.CORS.AllowedOrigins) != 1 || cfg.CORS.AllowedOrigins[0] != "http://example.com" {
-		t.Fatalf("expected CORS origin http://example.com, got %v", cfg.CORS.AllowedOrigins)
-	}
-	if !cfg.CORS.AllowCredentials {
-		t.Fatalf("expected CORS allow credentials true, got %v", cfg.CORS.AllowCredentials)
-	}
-	if len(cfg.Vaults) != 1 {
-		t.Fatalf("expected 1 vault, got %d", len(cfg.Vaults))
-	}
-	if cfg.Vaults[0].ID != "test-vault" {
-		t.Fatalf("expected vault ID test-vault, got %s", cfg.Vaults[0].ID)
-	}
-	if cfg.ExpirationThresholds.Critical != 14 {
-		t.Fatalf("expected critical threshold 14, got %d", cfg.ExpirationThresholds.Critical)
-	}
-	if cfg.ExpirationThresholds.Warning != 60 {
-		t.Fatalf("expected warning threshold 60, got %d", cfg.ExpirationThresholds.Warning)
-	}
-	if !cfg.Metrics.PerCertificate {
-		t.Fatalf("expected per certificate metrics true, got %v", cfg.Metrics.PerCertificate)
-	}
-	if cfg.Metrics.EnhancedMetrics {
-		t.Fatalf("expected enhanced metrics false, got %v", cfg.Metrics.EnhancedMetrics)
-	}
-	if cfg.TrustProxy {
-		t.Fatalf("expected TrustProxy false when omitted, got true")
-	}
+	assert.Equal(t, EnvProd, cfg.Env)
+	assert.Equal(t, "1234", cfg.Port)
+	assert.Equal(t, "warn", cfg.LogLevel)
+	assert.Equal(t, "json", cfg.LogFormat)
+	assert.Equal(t, []string{"http://example.com"}, cfg.CORS.AllowedOrigins)
+	assert.True(t, cfg.CORS.AllowCredentials)
+	require.Len(t, cfg.Vaults, 1)
+	assert.Equal(t, "test-vault", cfg.Vaults[0].ID)
+	assert.Equal(t, 14, cfg.ExpirationThresholds.Critical)
+	assert.Equal(t, 60, cfg.ExpirationThresholds.Warning)
+	assert.True(t, cfg.Metrics.PerCertificate)
+	assert.False(t, cfg.Metrics.EnhancedMetrics)
+	assert.False(t, cfg.TrustProxy)
 }
 
 func TestLoad_TrustProxyTrue(t *testing.T) {

--- a/app/internal/config/vault-multi_test.go
+++ b/app/internal/config/vault-multi_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoad_VaultsFromSettings(t *testing.T) {
@@ -207,29 +210,15 @@ func TestNormalizeVaultInstance(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := normalizeVaultInstance(tt.instance)
 			if tt.error {
-				if err == nil {
-					t.Fatalf("expected error but got none")
-				}
+				require.Error(t, err)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if result.ID != tt.expected.ID {
-				t.Fatalf("expected ID %s, got %s", tt.expected.ID, result.ID)
-			}
-			if result.Address != tt.expected.Address {
-				t.Fatalf("expected Address %s, got %s", tt.expected.Address, result.Address)
-			}
-			if result.Token != tt.expected.Token {
-				t.Fatalf("expected Token %s, got %s", tt.expected.Token, result.Token)
-			}
-			if result.DisplayName != tt.expected.DisplayName {
-				t.Fatalf("expected DisplayName %s, got %s", tt.expected.DisplayName, result.DisplayName)
-			}
-			if result.TLSInsecure != tt.expected.TLSInsecure {
-				t.Fatalf("expected TLSInsecure %v, got %v", tt.expected.TLSInsecure, result.TLSInsecure)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected.ID, result.ID)
+			assert.Equal(t, tt.expected.Address, result.Address)
+			assert.Equal(t, tt.expected.Token, result.Token)
+			assert.Equal(t, tt.expected.DisplayName, result.DisplayName)
+			assert.Equal(t, tt.expected.TLSInsecure, result.TLSInsecure)
 		})
 	}
 }

--- a/app/internal/handlers/admin.go
+++ b/app/internal/handlers/admin.go
@@ -302,6 +302,37 @@ func shouldFallbackToDirectWrite(err error) bool {
 	return false
 }
 
+// validateVaultInstance validates one vault entry and normalizes its PKI
+// mount fields. seen tracks duplicate IDs across the whole settings file.
+func validateVaultInstance(vault config.VaultInstance, seen map[string]struct{}) (config.VaultInstance, error) {
+	id := strings.TrimSpace(vault.ID)
+	address := strings.TrimSpace(vault.Address)
+	token := strings.TrimSpace(vault.Token)
+	if id == "" {
+		return vault, vcverrors.ErrVaultIDEmpty
+	}
+	if _, ok := seen[id]; ok {
+		return vault, vcverrors.ErrDuplicateVaultID
+	}
+	seen[id] = struct{}{}
+	if address == "" {
+		return vault, errors.New("vault address is empty")
+	}
+	if _, err := url.ParseRequestURI(address); err != nil {
+		return vault, vcverrors.ErrInvalidAddress
+	}
+	if token == "" {
+		return vault, vcverrors.ErrInvalidToken
+	}
+	if len(vault.PKIMounts) == 0 {
+		if strings.TrimSpace(vault.PKIMount) == "" {
+			vault.PKIMount = "pki"
+		}
+		vault.PKIMounts = []string{vault.PKIMount}
+	}
+	return vault, nil
+}
+
 func validateSettings(settings config.SettingsFile) error {
 	if webhookURL := strings.TrimSpace(settings.Notifications.WebhookURL); webhookURL != "" {
 		parsed, err := url.Parse(webhookURL)
@@ -314,31 +345,11 @@ func validateSettings(settings config.SettingsFile) error {
 	copy(normalizedVaults, settings.Vaults)
 	seen := make(map[string]struct{})
 	for i, vault := range normalizedVaults {
-		id := strings.TrimSpace(vault.ID)
-		address := strings.TrimSpace(vault.Address)
-		token := strings.TrimSpace(vault.Token)
-		if id == "" {
-			return vcverrors.ErrVaultIDEmpty
+		normalized, err := validateVaultInstance(vault, seen)
+		if err != nil {
+			return err
 		}
-		if _, ok := seen[id]; ok {
-			return vcverrors.ErrDuplicateVaultID
-		}
-		seen[id] = struct{}{}
-		if address == "" {
-			return errors.New("vault address is empty")
-		}
-		if _, err := url.ParseRequestURI(address); err != nil {
-			return vcverrors.ErrInvalidAddress
-		}
-		if token == "" {
-			return vcverrors.ErrInvalidToken
-		}
-		if len(vault.PKIMounts) == 0 {
-			if strings.TrimSpace(vault.PKIMount) == "" {
-				normalizedVaults[i].PKIMount = "pki"
-			}
-			normalizedVaults[i].PKIMounts = []string{normalizedVaults[i].PKIMount}
-		}
+		normalizedVaults[i] = normalized
 	}
 	return nil
 }

--- a/app/internal/handlers/admin_api.go
+++ b/app/internal/handlers/admin_api.go
@@ -149,40 +149,7 @@ func registerAdminAPIRoutes(
 			writeJSON(w, http.StatusOK, adminSettingsResponse{Settings: maskSecrets(settings), VaultStatuses: statuses})
 		})
 
-		r.Put("/api/admin/settings", func(w http.ResponseWriter, req *http.Request) {
-			var incoming config.SettingsFile
-			if err := json.NewDecoder(req.Body).Decode(&incoming); err != nil {
-				writeJSONError(w, http.StatusBadRequest, "invalid settings payload")
-				return
-			}
-			current, err := store.load()
-			if err != nil {
-				writeJSONError(w, http.StatusInternalServerError, errLoadSettings)
-				return
-			}
-			merged := mergeAdminSettings(current, incoming)
-			if saveErr := store.save(merged); saveErr != nil {
-				status := http.StatusBadRequest
-				if !errors.Is(saveErr, vcverrors.ErrInvalidAddress) &&
-					!errors.Is(saveErr, vcverrors.ErrInvalidToken) &&
-					!errors.Is(saveErr, vcverrors.ErrInvalidThreshold) &&
-					!errors.Is(saveErr, vcverrors.ErrInvalidWebhookURL) &&
-					!errors.Is(saveErr, vcverrors.ErrVaultIDEmpty) &&
-					!errors.Is(saveErr, vcverrors.ErrDuplicateVaultID) {
-					status = http.StatusInternalServerError
-				}
-				writeJSONError(w, status, saveErr.Error())
-				return
-			}
-			refreshRegistry()
-			updated, err := store.load()
-			if err != nil {
-				writeJSONError(w, http.StatusInternalServerError, "failed to reload settings")
-				return
-			}
-			statuses := computeVaultStatuses(req.Context(), updated.Vaults, vaultStatusClients)
-			writeJSON(w, http.StatusOK, adminSettingsResponse{Settings: maskSecrets(updated), VaultStatuses: statuses})
-		})
+		r.Put("/api/admin/settings", adminSettingsPut(store, vaultStatusClients, refreshRegistry))
 
 		r.Post("/api/admin/vault", func(w http.ResponseWriter, req *http.Request) {
 			key, err := newVaultKey()
@@ -203,43 +170,92 @@ func registerAdminAPIRoutes(
 			writeJSON(w, http.StatusOK, adminVaultAddedResponse{Key: key, Vault: vault})
 		})
 
-		r.Delete("/api/admin/vault/{id}", func(w http.ResponseWriter, req *http.Request) {
-			vaultID := strings.TrimSpace(chi.URLParam(req, "id"))
-			if vaultID == "" {
-				writeJSONError(w, http.StatusBadRequest, "vault id required")
-				return
-			}
-			settings, err := store.load()
-			if err != nil {
-				writeJSONError(w, http.StatusInternalServerError, errLoadSettings)
-				return
-			}
-			updatedVaults := make([]config.VaultInstance, 0, len(settings.Vaults))
-			removed := false
-			for _, vault := range settings.Vaults {
-				if strings.TrimSpace(vault.ID) == vaultID {
-					removed = true
-					continue
-				}
-				updatedVaults = append(updatedVaults, vault)
-			}
-			if !removed {
-				writeJSONError(w, http.StatusNotFound, "vault not found")
-				return
-			}
-			settings.Vaults = updatedVaults
-			if saveErr := store.save(settings); saveErr != nil {
-				requestID := middleware.GetRequestID(req.Context())
-				logger.HTTPError(req.Method, req.URL.Path, http.StatusInternalServerError, saveErr).
-					Str("request_id", requestID).
-					Msg("failed to save settings after vault removal")
-				writeJSONError(w, http.StatusInternalServerError, "failed to save settings")
-				return
-			}
-			refreshRegistry()
-			w.WriteHeader(http.StatusNoContent)
-		})
+		r.Delete("/api/admin/vault/{id}", adminVaultDelete(store, refreshRegistry))
 	})
+}
+
+// adminSettingsPut returns the handler for PUT /api/admin/settings: it merges
+// the incoming settings over the stored ones (preserving secrets) and saves.
+func adminSettingsPut(store *adminSettingsStore, vaultStatusClients map[string]vault.Client, refreshRegistry func()) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		var incoming config.SettingsFile
+		if err := json.NewDecoder(req.Body).Decode(&incoming); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid settings payload")
+			return
+		}
+		current, err := store.load()
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, errLoadSettings)
+			return
+		}
+		merged := mergeAdminSettings(current, incoming)
+		if saveErr := store.save(merged); saveErr != nil {
+			writeJSONError(w, validationErrorStatus(saveErr), saveErr.Error())
+			return
+		}
+		refreshRegistry()
+		updated, err := store.load()
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to reload settings")
+			return
+		}
+		statuses := computeVaultStatuses(req.Context(), updated.Vaults, vaultStatusClients)
+		writeJSON(w, http.StatusOK, adminSettingsResponse{Settings: maskSecrets(updated), VaultStatuses: statuses})
+	}
+}
+
+// validationErrorStatus maps settings validation errors to 400 and everything
+// else to 500.
+func validationErrorStatus(saveErr error) int {
+	if errors.Is(saveErr, vcverrors.ErrInvalidAddress) ||
+		errors.Is(saveErr, vcverrors.ErrInvalidToken) ||
+		errors.Is(saveErr, vcverrors.ErrInvalidThreshold) ||
+		errors.Is(saveErr, vcverrors.ErrInvalidWebhookURL) ||
+		errors.Is(saveErr, vcverrors.ErrVaultIDEmpty) ||
+		errors.Is(saveErr, vcverrors.ErrDuplicateVaultID) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}
+
+// adminVaultDelete returns the handler for DELETE /api/admin/vault/{id}.
+func adminVaultDelete(store *adminSettingsStore, refreshRegistry func()) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		vaultID := strings.TrimSpace(chi.URLParam(req, "id"))
+		if vaultID == "" {
+			writeJSONError(w, http.StatusBadRequest, "vault id required")
+			return
+		}
+		settings, err := store.load()
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, errLoadSettings)
+			return
+		}
+		updatedVaults := make([]config.VaultInstance, 0, len(settings.Vaults))
+		removed := false
+		for _, vault := range settings.Vaults {
+			if strings.TrimSpace(vault.ID) == vaultID {
+				removed = true
+				continue
+			}
+			updatedVaults = append(updatedVaults, vault)
+		}
+		if !removed {
+			writeJSONError(w, http.StatusNotFound, "vault not found")
+			return
+		}
+		settings.Vaults = updatedVaults
+		if saveErr := store.save(settings); saveErr != nil {
+			requestID := middleware.GetRequestID(req.Context())
+			logger.HTTPError(req.Method, req.URL.Path, http.StatusInternalServerError, saveErr).
+				Str("request_id", requestID).
+				Msg("failed to save settings after vault removal")
+			writeJSONError(w, http.StatusInternalServerError, "failed to save settings")
+			return
+		}
+		refreshRegistry()
+		w.WriteHeader(http.StatusNoContent)
+	}
 }
 
 func mergeAdminSettings(current, incoming config.SettingsFile) config.SettingsFile {
@@ -300,6 +316,31 @@ func isBlankOrMaskedSecret(token string) bool {
 	return false
 }
 
+// restoreVaultToken preserves the stored token when the incoming one is
+// blank or masked (vaults are keyed by OriginalID, falling back to ID).
+func restoreVaultToken(v *config.VaultInstance, tokens map[string]string) {
+	if !isBlankOrMaskedSecret(v.Token) {
+		return
+	}
+	lookupKey := v.OriginalID
+	if lookupKey == "" {
+		lookupKey = v.ID
+	}
+	if prior, ok := tokens[lookupKey]; ok {
+		v.Token = prior
+	}
+}
+
+// normalizePKIMounts keeps the PKIMount and PKIMounts fields consistent.
+func normalizePKIMounts(v *config.VaultInstance) {
+	if len(v.PKIMounts) == 0 && strings.TrimSpace(v.PKIMount) != "" {
+		v.PKIMounts = []string{strings.TrimSpace(v.PKIMount)}
+	}
+	if strings.TrimSpace(v.PKIMount) == "" && len(v.PKIMounts) > 0 {
+		v.PKIMount = v.PKIMounts[0]
+	}
+}
+
 func mergeVaultTokens(incoming, existing []config.VaultInstance) []config.VaultInstance {
 	tokens := make(map[string]string, len(existing))
 	for _, v := range existing {
@@ -307,22 +348,9 @@ func mergeVaultTokens(incoming, existing []config.VaultInstance) []config.VaultI
 	}
 	merged := make([]config.VaultInstance, 0, len(incoming))
 	for _, v := range incoming {
-		if isBlankOrMaskedSecret(v.Token) {
-			lookupKey := v.OriginalID
-			if lookupKey == "" {
-				lookupKey = v.ID
-			}
-			if prior, ok := tokens[lookupKey]; ok {
-				v.Token = prior
-			}
-		}
+		restoreVaultToken(&v, tokens)
 		v.OriginalID = ""
-		if len(v.PKIMounts) == 0 && strings.TrimSpace(v.PKIMount) != "" {
-			v.PKIMounts = []string{strings.TrimSpace(v.PKIMount)}
-		}
-		if strings.TrimSpace(v.PKIMount) == "" && len(v.PKIMounts) > 0 {
-			v.PKIMount = v.PKIMounts[0]
-		}
+		normalizePKIMounts(&v)
 		merged = append(merged, v)
 	}
 	return merged

--- a/app/internal/handlers/admin_api.go
+++ b/app/internal/handlers/admin_api.go
@@ -47,8 +47,16 @@ type adminVaultAddedResponse struct {
 	Vault config.VaultInstance `json:"vault"`
 }
 
+const (
+	contentTypeHeader = "Content-Type"
+	contentTypeJSON   = "application/json"
+	// errLoadSettings is the sanitized message returned when the settings
+	// file cannot be read or parsed.
+	errLoadSettings = "failed to load settings"
+)
+
 func writeJSON(w http.ResponseWriter, status int, body any) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	w.WriteHeader(status)
 	if body == nil {
 		return
@@ -134,7 +142,7 @@ func registerAdminAPIRoutes(
 		r.Get("/api/admin/settings", func(w http.ResponseWriter, req *http.Request) {
 			settings, err := store.load()
 			if err != nil {
-				writeJSONError(w, http.StatusInternalServerError, "failed to load settings")
+				writeJSONError(w, http.StatusInternalServerError, errLoadSettings)
 				return
 			}
 			statuses := computeVaultStatuses(req.Context(), settings.Vaults, vaultStatusClients)
@@ -149,7 +157,7 @@ func registerAdminAPIRoutes(
 			}
 			current, err := store.load()
 			if err != nil {
-				writeJSONError(w, http.StatusInternalServerError, "failed to load settings")
+				writeJSONError(w, http.StatusInternalServerError, errLoadSettings)
 				return
 			}
 			merged := mergeAdminSettings(current, incoming)
@@ -203,7 +211,7 @@ func registerAdminAPIRoutes(
 			}
 			settings, err := store.load()
 			if err != nil {
-				writeJSONError(w, http.StatusInternalServerError, "failed to load settings")
+				writeJSONError(w, http.StatusInternalServerError, errLoadSettings)
 				return
 			}
 			updatedVaults := make([]config.VaultInstance, 0, len(settings.Vaults))

--- a/app/internal/handlers/certs.go
+++ b/app/internal/handlers/certs.go
@@ -41,7 +41,14 @@ func listCertificatesWithErrors(ctx context.Context, client vault.Client) ([]cer
 }
 
 func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
-	r.Get("/api/certs", func(w http.ResponseWriter, req *http.Request) {
+	r.Get("/api/certs", listCertificatesHandler(vaultClient))
+	r.Get("/api/certs/{id}/details", certDetailsHandler(vaultClient))
+	r.Get("/api/certs/{id}/ca", certCAHandler(vaultClient))
+	r.Get("/api/certs/{id}/pem", certPEMHandler(vaultClient))
+}
+
+func listCertificatesHandler(vaultClient vault.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
 		// Parse mount filter from query parameters
 		selectedMounts := parseMountsQueryParam(req.URL.Query())
 		requestID := middleware.GetRequestID(req.Context())
@@ -83,9 +90,11 @@ func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
 			Int("vault_errors", len(vaultErrors)).
 			Strs("mounts", selectedMounts).
 			Msg("certificates listed successfully")
-	})
+	}
+}
 
-	r.Get("/api/certs/{id}/details", func(w http.ResponseWriter, req *http.Request) {
+func certDetailsHandler(vaultClient vault.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
 		certificateID, statusCode, decodeErr := decodeCertificateIDParam(req)
 		if statusCode != http.StatusOK {
 			requestID := middleware.GetRequestID(req.Context())
@@ -124,9 +133,11 @@ func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
 			Str("request_id", requestID).
 			Str("serial_number", certificateID).
 			Msg("fetched certificate details")
-	})
+	}
+}
 
-	r.Get("/api/certs/{id}/ca", func(w http.ResponseWriter, req *http.Request) {
+func certCAHandler(vaultClient vault.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
 		certificateID, statusCode, decodeErr := decodeCertificateIDParam(req)
 		if statusCode != http.StatusOK {
 			requestID := middleware.GetRequestID(req.Context())
@@ -161,9 +172,11 @@ func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
 			Str("request_id", requestID).
 			Str("mount", vaultMountKey).
 			Msg("served intermediate CA")
-	})
+	}
+}
 
-	r.Get("/api/certs/{id}/pem", func(w http.ResponseWriter, req *http.Request) {
+func certPEMHandler(vaultClient vault.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
 		certificateID, statusCode, decodeErr := decodeCertificateIDParam(req)
 		if statusCode != http.StatusOK {
 			requestID := middleware.GetRequestID(req.Context())
@@ -199,8 +212,7 @@ func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
 			Str("request_id", requestID).
 			Str("serial_number", certificateID).
 			Msg("served certificate PEM")
-	})
-
+	}
 }
 
 func decodeCertificateIDParam(req *http.Request) (string, int, error) {

--- a/app/internal/handlers/certs.go
+++ b/app/internal/handlers/certs.go
@@ -69,7 +69,7 @@ func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
 		filteredCertificates := filterCertificatesByMounts(certificates, selectedMounts)
 		envelope := certsEnvelope{Certificates: filteredCertificates, Errors: vaultErrors}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentTypeHeader, contentTypeJSON)
 		if encodeErr := json.NewEncoder(w).Encode(envelope); encodeErr != nil {
 			logger.HTTPError(req.Method, req.URL.Path, http.StatusInternalServerError, encodeErr).
 				Str("request_id", requestID).
@@ -112,7 +112,7 @@ func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentTypeHeader, contentTypeJSON)
 		if err := json.NewEncoder(w).Encode(details); err != nil {
 			logger.HTTPError(req.Method, req.URL.Path, http.StatusInternalServerError, err).
 				Str("request_id", requestID).
@@ -147,7 +147,7 @@ func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentTypeHeader, contentTypeJSON)
 		if err := json.NewEncoder(w).Encode(caDetails); err != nil {
 			requestID := middleware.GetRequestID(req.Context())
 			logger.HTTPError(req.Method, req.URL.Path, http.StatusInternalServerError, err).
@@ -185,7 +185,7 @@ func RegisterCertRoutes(r chi.Router, vaultClient vault.Client) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentTypeHeader, contentTypeJSON)
 		if err := json.NewEncoder(w).Encode(pemResponse); err != nil {
 			requestID := middleware.GetRequestID(req.Context())
 			logger.HTTPError(req.Method, req.URL.Path, http.StatusInternalServerError, err).

--- a/app/internal/handlers/config.go
+++ b/app/internal/handlers/config.go
@@ -43,6 +43,30 @@ func publicVaultPKIMounts(instance config.VaultInstance) []string {
 	return []string{}
 }
 
+// publicVaultResponses builds the visible vault list for the public config API.
+func publicVaultResponses(cfg config.Config, vaultRegistry *vault.Registry) []VaultConfigResponse {
+	allVaults := cfg.AllVaults
+	if len(allVaults) == 0 {
+		allVaults = cfg.Vaults
+	}
+	resp := make([]VaultConfigResponse, 0, len(allVaults))
+	for _, instance := range allVaults {
+		vaultID := instance.ID
+		if vaultID == "" {
+			continue
+		}
+		if vaultRegistry != nil && !vaultRegistry.IsEnabled(vaultID) {
+			continue
+		}
+		displayName := instance.DisplayName
+		if displayName == "" {
+			displayName = vaultID
+		}
+		resp = append(resp, VaultConfigResponse{ID: vaultID, DisplayName: displayName, PKIMounts: publicVaultPKIMounts(instance)})
+	}
+	return resp
+}
+
 // GetConfig returns the application configuration.
 func GetConfig(cfg config.Config, vaultRegistry *vault.Registry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -59,26 +83,7 @@ func GetConfig(cfg config.Config, vaultRegistry *vault.Registry) http.HandlerFun
 		if resp.PKIMounts == nil {
 			resp.PKIMounts = []string{}
 		}
-		allVaults := cfg.AllVaults
-		if len(allVaults) == 0 {
-			allVaults = cfg.Vaults
-		}
-		resp.Vaults = make([]VaultConfigResponse, 0, len(allVaults))
-		for _, instance := range allVaults {
-			vaultID := instance.ID
-			if vaultID == "" {
-				continue
-			}
-			if vaultRegistry != nil && !vaultRegistry.IsEnabled(vaultID) {
-				continue
-			}
-			displayName := instance.DisplayName
-			if displayName == "" {
-				displayName = vaultID
-			}
-			pkiMounts := publicVaultPKIMounts(instance)
-			resp.Vaults = append(resp.Vaults, VaultConfigResponse{ID: vaultID, DisplayName: displayName, PKIMounts: pkiMounts})
-		}
+		resp.Vaults = publicVaultResponses(cfg, vaultRegistry)
 
 		w.Header().Set("Content-Type", "application/json")
 

--- a/app/internal/i18n/i18n.go
+++ b/app/internal/i18n/i18n.go
@@ -237,10 +237,28 @@ type Response struct {
 	Messages Messages `json:"messages"`
 }
 
+// Shared literals reused verbatim across language bundles (fallbacks kept
+// identical where no translation is needed).
+const (
+	msgAppSubtitle        = "Monitor Vault/OpenBao certificate expirations"
+	msgSearchShortcutHint = "Press / to focus search"
+	msgResetFilters       = "Reset filters"
+	msgSourcesAll         = "Sources: {total}/{total}"
+	msgSourcesPartial     = "Sources: {selected}/{total}"
+	msgAdminTitle         = "VaultCertsViewer Admin"
+	msgVaultsOK           = "Vaults: {{up}}/{{total}} OK"
+	msgLangResolved       = "language resolved"
+	msgWithinDaysEN       = "≤ {days} days"
+	msgWithinDaysFR       = "≤ {days} jours"
+	msgWithinDaysES       = "≤ {days} días"
+	msgWithinDaysDE       = "≤ {days} Tage"
+	msgWithinDaysIT       = "≤ {days} giorni"
+)
+
 var englishMessages = Messages{
 	AppTitle:                       "VaultCertsViewer",
-	AppSubtitle:                    "Monitor Vault/OpenBao certificate expirations",
-	SearchShortcutHint:             "Press / to focus search",
+	AppSubtitle:                    msgAppSubtitle,
+	SearchShortcutHint:             msgSearchShortcutHint,
 	ButtonToggleTheme:              "Toggle theme",
 	ButtonClose:                    "Close",
 	ButtonDetails:                  "Details",
@@ -330,7 +348,7 @@ var englishMessages = Messages{
 	SortByColumn:                   "Sort by {column}",
 	DashboardResultCount:           "{count} certificates",
 	ExpiryTimelineLabel:            "Upcoming expirations",
-	TimelineWithinDays:             "≤ {days} days",
+	TimelineWithinDays:             msgWithinDaysEN,
 	TimelineRangeDays:              "{from}–{to} days",
 	TimelineBeyondDays:             "> {days} days",
 	SearchPlaceholder:              "Search by Serial Number, Common Name (CN) or SAN",
@@ -339,15 +357,15 @@ var englishMessages = Messages{
 	FilterChipStatus:               "Status",
 	FilterChipCertType:             "Type",
 	FilterChipSources:              "Sources",
-	FilterChipReset:                "Reset filters",
-	SourcesButtonAll:               "Sources: {total}/{total}",
-	SourcesButtonPartial:           "Sources: {selected}/{total}",
+	FilterChipReset:                msgResetFilters,
+	SourcesButtonAll:               msgSourcesAll,
+	SourcesButtonPartial:           msgSourcesPartial,
 	StatusLabelExpired:             "Expired",
 	StatusLabelRevoked:             "Revoked",
 	StatusLabelValid:               "Valid",
 	VaultConnectionLost:            "Vault connection lost",
 	VaultConnectionRestored:        "Vault connection restored",
-	AdminTitle:                     "VaultCertsViewer Admin",
+	AdminTitle:                     msgAdminTitle,
 	AdminBackToVCV:                 "Back to VCV",
 	AdminSettingsSaved:             "Settings saved",
 	AdminLogoutFailed:              "Logout failed",
@@ -404,8 +422,8 @@ var englishMessages = Messages{
 	StatusLabelCritical:        "Critical",
 	StatusLabelWarning:         "Warning",
 	StatusDescValid:            "All good",
-	StatusDescWarning:          "≤ {days} days",
-	StatusDescCritical:         "≤ {days} days",
+	StatusDescWarning:          msgWithinDaysEN,
+	StatusDescCritical:         msgWithinDaysEN,
 	StatusDescExpired:          "Past expiry",
 	StatusDescRevoked:          "Revoked by CA",
 	LabelValidity:              "Validity",
@@ -538,7 +556,7 @@ var frenchMessages = Messages{
 	SortByColumn:                   "Trier par {column}",
 	DashboardResultCount:           "{count} certificats",
 	ExpiryTimelineLabel:            "Expirations à venir",
-	TimelineWithinDays:             "≤ {days} jours",
+	TimelineWithinDays:             msgWithinDaysFR,
 	TimelineRangeDays:              "{from}–{to} jours",
 	TimelineBeyondDays:             "> {days} jours",
 	SearchPlaceholder:              "Rechercher par numéro de série, nom commun (CN) ou SAN",
@@ -555,7 +573,7 @@ var frenchMessages = Messages{
 	StatusLabelValid:               "Valide",
 	VaultConnectionLost:            "Connexion à Vault perdue",
 	VaultConnectionRestored:        "Connexion à Vault rétablie",
-	AdminTitle:                     "VaultCertsViewer Admin",
+	AdminTitle:                     msgAdminTitle,
 	AdminBackToVCV:                 "Retour à VCV",
 	AdminSettingsSaved:             "Paramètres enregistrés",
 	AdminLogoutFailed:              "Échec de la déconnexion",
@@ -612,8 +630,8 @@ var frenchMessages = Messages{
 	StatusLabelCritical:        "Critique",
 	StatusLabelWarning:         "Avertissement",
 	StatusDescValid:            "Tout va bien",
-	StatusDescWarning:          "≤ {days} jours",
-	StatusDescCritical:         "≤ {days} jours",
+	StatusDescWarning:          msgWithinDaysFR,
+	StatusDescCritical:         msgWithinDaysFR,
 	StatusDescExpired:          "Date dépassée",
 	StatusDescRevoked:          "Révoqué par l'autorité",
 	LabelValidity:              "Validité",
@@ -655,8 +673,8 @@ var frenchMessages = Messages{
 
 var spanishMessages = Messages{
 	AppTitle:                       "VaultCertsViewer",
-	AppSubtitle:                    "Monitor Vault/OpenBao certificate expirations",
-	SearchShortcutHint:             "Press / to focus search",
+	AppSubtitle:                    msgAppSubtitle,
+	SearchShortcutHint:             msgSearchShortcutHint,
 	ButtonToggleTheme:              "Cambiar tema",
 	ButtonClose:                    "Cerrar",
 	ButtonDetails:                  "Detalles",
@@ -702,7 +720,7 @@ var spanishMessages = Messages{
 	CertTypeFilterMachine:          "Máquina",
 	CertTypeFilterUnknown:          "Tipo desconocido",
 	CertTypeFilterUser:             "Usuario",
-	FooterVaultSummary:             "Vaults: {{up}}/{{total}} OK",
+	FooterVaultSummary:             msgVaultsOK,
 	LabelFingerprintSHA1:           "Huella SHA-1",
 	LabelFingerprintSHA256:         "Huella SHA-256",
 	LabelIssuer:                    "Emisor",
@@ -746,7 +764,7 @@ var spanishMessages = Messages{
 	SortByColumn:                   "Ordenar por {column}",
 	DashboardResultCount:           "{count} certificados",
 	ExpiryTimelineLabel:            "Próximos vencimientos",
-	TimelineWithinDays:             "≤ {days} días",
+	TimelineWithinDays:             msgWithinDaysES,
 	TimelineRangeDays:              "{from}–{to} días",
 	TimelineBeyondDays:             "> {days} días",
 	SearchPlaceholder:              "Buscar por Número de Serie, Nombre Común (CN) o SAN",
@@ -755,15 +773,15 @@ var spanishMessages = Messages{
 	FilterChipStatus:               "Status",
 	FilterChipCertType:             "Type",
 	FilterChipSources:              "Sources",
-	FilterChipReset:                "Reset filters",
-	SourcesButtonAll:               "Sources: {total}/{total}",
-	SourcesButtonPartial:           "Sources: {selected}/{total}",
+	FilterChipReset:                msgResetFilters,
+	SourcesButtonAll:               msgSourcesAll,
+	SourcesButtonPartial:           msgSourcesPartial,
 	StatusLabelExpired:             "Caducado",
 	StatusLabelRevoked:             "Revocado",
 	StatusLabelValid:               "Válido",
 	VaultConnectionLost:            "Conexión a Vault perdida",
 	VaultConnectionRestored:        "Conexión a Vault restablecida",
-	AdminTitle:                     "VaultCertsViewer Admin",
+	AdminTitle:                     msgAdminTitle,
 	AdminBackToVCV:                 "Volver a VCV",
 	AdminSettingsSaved:             "Configuración guardada",
 	AdminLogoutFailed:              "Error al cerrar sesión",
@@ -820,8 +838,8 @@ var spanishMessages = Messages{
 	StatusLabelCritical:        "Crítico",
 	StatusLabelWarning:         "Advertencia",
 	StatusDescValid:            "Todo correcto",
-	StatusDescWarning:          "≤ {days} días",
-	StatusDescCritical:         "≤ {days} días",
+	StatusDescWarning:          msgWithinDaysES,
+	StatusDescCritical:         msgWithinDaysES,
 	StatusDescExpired:          "Fecha vencida",
 	StatusDescRevoked:          "Revocado por la autoridad",
 	LabelValidity:              "Validez",
@@ -863,8 +881,8 @@ var spanishMessages = Messages{
 
 var germanMessages = Messages{
 	AppTitle:                       "VaultCertsViewer",
-	AppSubtitle:                    "Monitor Vault/OpenBao certificate expirations",
-	SearchShortcutHint:             "Press / to focus search",
+	AppSubtitle:                    msgAppSubtitle,
+	SearchShortcutHint:             msgSearchShortcutHint,
 	ButtonToggleTheme:              "Design umschalten",
 	ButtonClose:                    "Schließen",
 	ButtonDetails:                  "Details",
@@ -910,7 +928,7 @@ var germanMessages = Messages{
 	CertTypeFilterMachine:          "Maschine",
 	CertTypeFilterUnknown:          "Unbekannter Typ",
 	CertTypeFilterUser:             "Benutzer",
-	FooterVaultSummary:             "Vaults: {{up}}/{{total}} OK",
+	FooterVaultSummary:             msgVaultsOK,
 	LabelFingerprintSHA1:           "SHA-1-Fingerabdruck",
 	LabelFingerprintSHA256:         "SHA-256-Fingerabdruck",
 	LabelIssuer:                    "Aussteller",
@@ -954,7 +972,7 @@ var germanMessages = Messages{
 	SortByColumn:                   "Sortieren nach {column}",
 	DashboardResultCount:           "{count} Zertifikate",
 	ExpiryTimelineLabel:            "Bevorstehende Abläufe",
-	TimelineWithinDays:             "≤ {days} Tage",
+	TimelineWithinDays:             msgWithinDaysDE,
 	TimelineRangeDays:              "{from}–{to} Tage",
 	TimelineBeyondDays:             "> {days} Tage",
 	SearchPlaceholder:              "Suche nach Seriennummer, Common Name (CN) oder SAN",
@@ -963,15 +981,15 @@ var germanMessages = Messages{
 	FilterChipStatus:               "Status",
 	FilterChipCertType:             "Type",
 	FilterChipSources:              "Sources",
-	FilterChipReset:                "Reset filters",
-	SourcesButtonAll:               "Sources: {total}/{total}",
-	SourcesButtonPartial:           "Sources: {selected}/{total}",
+	FilterChipReset:                msgResetFilters,
+	SourcesButtonAll:               msgSourcesAll,
+	SourcesButtonPartial:           msgSourcesPartial,
 	StatusLabelExpired:             "Abgelaufen",
 	StatusLabelRevoked:             "Widerrufen",
 	StatusLabelValid:               "Gültig",
 	VaultConnectionLost:            "Verbindung zu Vault unterbrochen",
 	VaultConnectionRestored:        "Verbindung zu Vault wiederhergestellt",
-	AdminTitle:                     "VaultCertsViewer Admin",
+	AdminTitle:                     msgAdminTitle,
 	AdminBackToVCV:                 "Zurück zu VCV",
 	AdminSettingsSaved:             "Einstellungen gespeichert",
 	AdminLogoutFailed:              "Abmelden fehlgeschlagen",
@@ -1028,8 +1046,8 @@ var germanMessages = Messages{
 	StatusLabelCritical:        "Kritisch",
 	StatusLabelWarning:         "Warnung",
 	StatusDescValid:            "Alles in Ordnung",
-	StatusDescWarning:          "≤ {days} Tage",
-	StatusDescCritical:         "≤ {days} Tage",
+	StatusDescWarning:          msgWithinDaysDE,
+	StatusDescCritical:         msgWithinDaysDE,
 	StatusDescExpired:          "Abgelaufen",
 	StatusDescRevoked:          "Von der CA widerrufen",
 	LabelValidity:              "Gültigkeit",
@@ -1071,8 +1089,8 @@ var germanMessages = Messages{
 
 var italianMessages = Messages{
 	AppTitle:                       "VaultCertsViewer",
-	AppSubtitle:                    "Monitor Vault/OpenBao certificate expirations",
-	SearchShortcutHint:             "Press / to focus search",
+	AppSubtitle:                    msgAppSubtitle,
+	SearchShortcutHint:             msgSearchShortcutHint,
 	ButtonToggleTheme:              "Cambia tema",
 	ButtonClose:                    "Chiudi",
 	ButtonDetails:                  "Dettagli",
@@ -1118,7 +1136,7 @@ var italianMessages = Messages{
 	CertTypeFilterMachine:          "Macchina",
 	CertTypeFilterUnknown:          "Tipo sconosciuto",
 	CertTypeFilterUser:             "Utente",
-	FooterVaultSummary:             "Vaults: {{up}}/{{total}} OK",
+	FooterVaultSummary:             msgVaultsOK,
 	LabelFingerprintSHA1:           "Impronta SHA-1",
 	LabelFingerprintSHA256:         "Impronta SHA-256",
 	LabelIssuer:                    "Emittente",
@@ -1162,7 +1180,7 @@ var italianMessages = Messages{
 	SortByColumn:                   "Ordina per {column}",
 	DashboardResultCount:           "{count} certificati",
 	ExpiryTimelineLabel:            "Scadenze imminenti",
-	TimelineWithinDays:             "≤ {days} giorni",
+	TimelineWithinDays:             msgWithinDaysIT,
 	TimelineRangeDays:              "{from}–{to} giorni",
 	TimelineBeyondDays:             "> {days} giorni",
 	SearchPlaceholder:              "Cerca per Numero di Serie, Nome Comune (CN) o SAN",
@@ -1171,15 +1189,15 @@ var italianMessages = Messages{
 	FilterChipStatus:               "Status",
 	FilterChipCertType:             "Type",
 	FilterChipSources:              "Sources",
-	FilterChipReset:                "Reset filters",
-	SourcesButtonAll:               "Sources: {total}/{total}",
-	SourcesButtonPartial:           "Sources: {selected}/{total}",
+	FilterChipReset:                msgResetFilters,
+	SourcesButtonAll:               msgSourcesAll,
+	SourcesButtonPartial:           msgSourcesPartial,
 	StatusLabelExpired:             "Scaduto",
 	StatusLabelRevoked:             "Revocato",
 	StatusLabelValid:               "Valido",
 	VaultConnectionLost:            "Connessione al Vault interrotta",
 	VaultConnectionRestored:        "Connessione al Vault ripristinata",
-	AdminTitle:                     "VaultCertsViewer Admin",
+	AdminTitle:                     msgAdminTitle,
 	AdminBackToVCV:                 "Torna a VCV",
 	AdminSettingsSaved:             "Impostazioni salvate",
 	AdminLogoutFailed:              "Disconnessione non riuscita",
@@ -1236,8 +1254,8 @@ var italianMessages = Messages{
 	StatusLabelCritical:        "Critico",
 	StatusLabelWarning:         "Avviso",
 	StatusDescValid:            "Tutto a posto",
-	StatusDescWarning:          "≤ {days} giorni",
-	StatusDescCritical:         "≤ {days} giorni",
+	StatusDescWarning:          msgWithinDaysIT,
+	StatusDescCritical:         msgWithinDaysIT,
 	StatusDescExpired:          "Data superata",
 	StatusDescRevoked:          "Revocato dalla CA",
 	LabelValidity:              "Validità",
@@ -1347,7 +1365,7 @@ func ResolveLanguage(r *http.Request) Language {
 	// 1. Check query parameter
 	if lang := r.URL.Query().Get("lang"); lang != "" {
 		if l, ok := GetLanguage(lang); ok {
-			logger.Get().Debug().Str("source", "query_param").Str("lang", lang).Msg("language resolved")
+			logger.Get().Debug().Str("source", "query_param").Str("lang", lang).Msg(msgLangResolved)
 			return l
 		}
 	}
@@ -1360,7 +1378,7 @@ func ResolveLanguage(r *http.Request) Language {
 			headerLanguage := parsed.Query().Get("lang")
 			if headerLanguage != "" {
 				if language, ok := GetLanguage(headerLanguage); ok {
-					logger.Get().Debug().Str("source", "hx_current_url").Str("lang", headerLanguage).Msg("language resolved")
+					logger.Get().Debug().Str("source", "hx_current_url").Str("lang", headerLanguage).Msg(msgLangResolved)
 					return language
 				}
 			}
@@ -1370,7 +1388,7 @@ func ResolveLanguage(r *http.Request) Language {
 	// 3. Check cookie
 	if cookie, err := r.Cookie("lang"); err == nil {
 		if l, ok := GetLanguage(cookie.Value); ok {
-			logger.Get().Debug().Str("source", "cookie").Str("lang", cookie.Value).Msg("language resolved")
+			logger.Get().Debug().Str("source", "cookie").Str("lang", cookie.Value).Msg(msgLangResolved)
 			return l
 		}
 	}
@@ -1378,6 +1396,6 @@ func ResolveLanguage(r *http.Request) Language {
 	// 4. Use Accept-Language header
 	acceptLang := r.Header.Get("Accept-Language")
 	lang := FromAcceptLanguage(acceptLang)
-	logger.Get().Debug().Str("source", "accept_language").Str("header", acceptLang).Str("lang", string(lang)).Msg("language resolved")
+	logger.Get().Debug().Str("source", "accept_language").Str("header", acceptLang).Str("lang", string(lang)).Msg(msgLangResolved)
 	return lang
 }

--- a/app/internal/i18n/i18n.go
+++ b/app/internal/i18n/i18n.go
@@ -1360,6 +1360,28 @@ func FromAcceptLanguage(headerValue string) Language {
 	return LanguageEnglish
 }
 
+// languageFromHXCurrentURL extracts a valid language from the legacy
+// hx-current-url header, if present.
+func languageFromHXCurrentURL(r *http.Request) (Language, bool) {
+	currentURL := r.Header.Get("hx-current-url")
+	if currentURL == "" {
+		return LanguageEnglish, false
+	}
+	parsed, err := url.Parse(currentURL)
+	if err != nil {
+		return LanguageEnglish, false
+	}
+	headerLanguage := parsed.Query().Get("lang")
+	if headerLanguage == "" {
+		return LanguageEnglish, false
+	}
+	if language, ok := GetLanguage(headerLanguage); ok {
+		logger.Get().Debug().Str("source", "hx_current_url").Str("lang", headerLanguage).Msg(msgLangResolved)
+		return language, true
+	}
+	return LanguageEnglish, false
+}
+
 // ResolveLanguage resolves the language from the request using query param, cookie, or Accept-Language header.
 func ResolveLanguage(r *http.Request) Language {
 	// 1. Check query parameter
@@ -1371,18 +1393,8 @@ func ResolveLanguage(r *http.Request) Language {
 	}
 
 	// 2. Check HX-Current-URL header
-	currentURL := r.Header.Get("hx-current-url")
-	if currentURL != "" {
-		parsed, err := url.Parse(currentURL)
-		if err == nil {
-			headerLanguage := parsed.Query().Get("lang")
-			if headerLanguage != "" {
-				if language, ok := GetLanguage(headerLanguage); ok {
-					logger.Get().Debug().Str("source", "hx_current_url").Str("lang", headerLanguage).Msg(msgLangResolved)
-					return language
-				}
-			}
-		}
+	if language, ok := languageFromHXCurrentURL(r); ok {
+		return language
 	}
 
 	// 3. Check cookie

--- a/app/internal/logger/logger.go
+++ b/app/internal/logger/logger.go
@@ -18,6 +18,35 @@ type Logger = zerolog.Logger
 // consoleTimeFormat is the timestamp layout used by the console (non-JSON) writer.
 const consoleTimeFormat = "2006-01-02 15:04:05"
 
+// newConsoleWriter returns a console writer for the given destination.
+func newConsoleWriter(out io.Writer) zerolog.ConsoleWriter {
+	return zerolog.ConsoleWriter{Out: out, TimeFormat: consoleTimeFormat}
+}
+
+// appendStdoutWriter appends the stdout writer (JSON or console) to writers.
+func appendStdoutWriter(writers []io.Writer, format string) []io.Writer {
+	if format == "json" {
+		return append(writers, os.Stdout)
+	}
+	return append(writers, newConsoleWriter(os.Stdout))
+}
+
+// appendFileWriter appends the log-file writer (JSON or console) to writers,
+// recording a deferred warning when the file cannot be used.
+func appendFileWriter(writers []io.Writer, deferredWarnings []string, logFilePath string, format string) ([]io.Writer, []string) {
+	if logFilePath == "" {
+		return writers, append(deferredWarnings, "LOG_OUTPUT requires a file but LOG_FILE_PATH is not set; disabling file logging")
+	}
+	file, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return writers, append(deferredWarnings, fmt.Sprintf("Failed to open log file '%s', disabling file logging: %v", logFilePath, err))
+	}
+	if format == "json" {
+		return append(writers, file), deferredWarnings
+	}
+	return append(writers, newConsoleWriter(file)), deferredWarnings
+}
+
 // Init initializes the logger with the specified log level
 func Init(level string) {
 	// Set time format
@@ -44,46 +73,17 @@ func Init(level string) {
 
 	// Configure stdout writer
 	if stdoutEnabled {
-		if format == "json" {
-			writers = append(writers, os.Stdout)
-		} else {
-			consoleWriter := zerolog.ConsoleWriter{
-				Out:        os.Stdout,
-				TimeFormat: consoleTimeFormat,
-			}
-			writers = append(writers, consoleWriter)
-		}
+		writers = appendStdoutWriter(writers, format)
 	}
 
 	// Configure file writer if requested
 	if fileEnabled {
-		if logFilePath == "" {
-			deferredWarnings = append(deferredWarnings, "LOG_OUTPUT requires a file but LOG_FILE_PATH is not set; disabling file logging")
-		} else {
-			file, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-			if err != nil {
-				deferredWarnings = append(deferredWarnings, fmt.Sprintf("Failed to open log file '%s', disabling file logging: %v", logFilePath, err))
-			} else {
-				if format == "json" {
-					writers = append(writers, file)
-				} else {
-					consoleWriter := zerolog.ConsoleWriter{
-						Out:        file,
-						TimeFormat: consoleTimeFormat,
-					}
-					writers = append(writers, consoleWriter)
-				}
-			}
-		}
+		writers, deferredWarnings = appendFileWriter(writers, deferredWarnings, logFilePath, format)
 	}
 
 	// Fallback: if no writers configured, use stdout console
 	if len(writers) == 0 {
-		consoleWriter := zerolog.ConsoleWriter{
-			Out:        os.Stdout,
-			TimeFormat: consoleTimeFormat,
-		}
-		writers = append(writers, consoleWriter)
+		writers = append(writers, newConsoleWriter(os.Stdout))
 		deferredWarnings = append(deferredWarnings, "No valid log output configured, falling back to stdout console")
 		stdoutEnabled = true
 		fileEnabled = false

--- a/app/internal/logger/logger.go
+++ b/app/internal/logger/logger.go
@@ -15,6 +15,9 @@ import (
 // This allows other packages to depend only on vcv/internal/logger instead of importing zerolog directly.
 type Logger = zerolog.Logger
 
+// consoleTimeFormat is the timestamp layout used by the console (non-JSON) writer.
+const consoleTimeFormat = "2006-01-02 15:04:05"
+
 // Init initializes the logger with the specified log level
 func Init(level string) {
 	// Set time format
@@ -46,7 +49,7 @@ func Init(level string) {
 		} else {
 			consoleWriter := zerolog.ConsoleWriter{
 				Out:        os.Stdout,
-				TimeFormat: "2006-01-02 15:04:05",
+				TimeFormat: consoleTimeFormat,
 			}
 			writers = append(writers, consoleWriter)
 		}
@@ -66,7 +69,7 @@ func Init(level string) {
 				} else {
 					consoleWriter := zerolog.ConsoleWriter{
 						Out:        file,
-						TimeFormat: "2006-01-02 15:04:05",
+						TimeFormat: consoleTimeFormat,
 					}
 					writers = append(writers, consoleWriter)
 				}
@@ -78,7 +81,7 @@ func Init(level string) {
 	if len(writers) == 0 {
 		consoleWriter := zerolog.ConsoleWriter{
 			Out:        os.Stdout,
-			TimeFormat: "2006-01-02 15:04:05",
+			TimeFormat: consoleTimeFormat,
 		}
 		writers = append(writers, consoleWriter)
 		deferredWarnings = append(deferredWarnings, "No valid log output configured, falling back to stdout console")

--- a/app/internal/metrics/certificate_collector.go
+++ b/app/internal/metrics/certificate_collector.go
@@ -553,19 +553,9 @@ func daysUntil(expiresAt time.Time, now time.Time) int {
 	return int(math.Ceil(diff.Hours() / 24))
 }
 
-func (collector *certificateCollector) emitEnhancedMetrics(ch chan<- prometheus.Metric, certificates []certs.Certificate, now time.Time) {
-	buckets := make(map[string]map[string]map[string]int)
-	for _, certificate := range certificates {
-		vaultID, pki := extractVaultIDAndPKI(certificate.ID)
-		if certificate.Revoked {
-			incCounter3(buckets, vaultID, pki, "revoked")
-			continue
-		}
-		if certificate.ExpiresAt.IsZero() {
-			continue
-		}
-		incCounter3(buckets, vaultID, pki, expiryBucketLabel(daysUntil(certificate.ExpiresAt.UTC(), now.UTC())))
-	}
+// emitExpiryBuckets emits per vault+PKI bucket metrics followed by the
+// aggregated all-vault totals.
+func emitExpiryBuckets(ch chan<- prometheus.Metric, buckets map[string]map[string]map[string]int) {
 	for _, vaultID := range sortedStringKeys(buckets) {
 		for _, pki := range sortedStringKeys(buckets[vaultID]) {
 			for _, bucket := range expiryBucketNames {
@@ -584,4 +574,20 @@ func (collector *certificateCollector) emitEnhancedMetrics(ch chan<- prometheus.
 	for _, bucket := range expiryBucketNames {
 		ch <- prometheus.MustNewConstMetric(expiryBucketDesc, prometheus.GaugeValue, float64(allBuckets[bucket]), allLabelValue, allLabelValue, bucket)
 	}
+}
+
+func (collector *certificateCollector) emitEnhancedMetrics(ch chan<- prometheus.Metric, certificates []certs.Certificate, now time.Time) {
+	buckets := make(map[string]map[string]map[string]int)
+	for _, certificate := range certificates {
+		vaultID, pki := extractVaultIDAndPKI(certificate.ID)
+		if certificate.Revoked {
+			incCounter3(buckets, vaultID, pki, "revoked")
+			continue
+		}
+		if certificate.ExpiresAt.IsZero() {
+			continue
+		}
+		incCounter3(buckets, vaultID, pki, expiryBucketLabel(daysUntil(certificate.ExpiresAt.UTC(), now.UTC())))
+	}
+	emitExpiryBuckets(ch, buckets)
 }

--- a/app/internal/metrics/certificate_collector.go
+++ b/app/internal/metrics/certificate_collector.go
@@ -31,6 +31,62 @@ func zeroExpiryBuckets() map[string]int {
 	return counts
 }
 
+// incCounter2 increments a vaultID → pki counter, allocating intermediate maps.
+func incCounter2(m map[string]map[string]int, vaultID string, pki string) {
+	if m[vaultID] == nil {
+		m[vaultID] = make(map[string]int)
+	}
+	m[vaultID][pki]++
+}
+
+// counter2At reads a vaultID → pki counter, returning 0 for missing keys.
+func counter2At(m map[string]map[string]int, vaultID string, pki string) int {
+	return m[vaultID][pki]
+}
+
+// incCounter3 increments a vaultID → pki → label counter, allocating intermediate maps.
+func incCounter3(m map[string]map[string]map[string]int, vaultID string, pki string, label string) {
+	if m[vaultID] == nil {
+		m[vaultID] = make(map[string]map[string]int)
+	}
+	if m[vaultID][pki] == nil {
+		m[vaultID][pki] = make(map[string]int)
+	}
+	m[vaultID][pki][label]++
+}
+
+// unionKeys returns the sorted union of the key sets of the given maps.
+func unionKeys[V any](maps ...map[string]V) []string {
+	seen := make(map[string]struct{})
+	for _, m := range maps {
+		for key := range m {
+			seen[key] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// expiryBucketLabel classifies days-until-expiry into an expiry bucket name.
+func expiryBucketLabel(daysRemaining int) string {
+	switch {
+	case daysRemaining < 0:
+		return "expired"
+	case daysRemaining <= 7:
+		return "0-7d"
+	case daysRemaining <= 30:
+		return "7-30d"
+	case daysRemaining <= 90:
+		return "30-90d"
+	default:
+		return "90d+"
+	}
+}
+
 // perCertificateCardinalityWarnThreshold logs an extra warn when inventory size exceeds this while per_certificate is on.
 const perCertificateCardinalityWarnThreshold = 500
 
@@ -361,36 +417,39 @@ func (collector *certificateCollector) emitVaultListingFailureMetrics(ch chan<- 
 	ch <- prometheus.MustNewConstMetric(partialScrapeDesc, prometheus.GaugeValue, 1, allLabelValue)
 }
 
+// tallyAggregation accumulates one certificate into the status totals and
+// expiring-soon counters keyed by vault+PKI.
+func (collector *certificateCollector) tallyAggregation(certificate certs.Certificate, now time.Time, totals map[string]map[string]int, soon map[string]map[string]int) {
+	vaultID, pki := extractVaultIDAndPKI(certificate.ID)
+	key := buildAggregationKey(vaultID, pki)
+	status := collector.statusLabel(certificate, now)
+	if totals[key] == nil {
+		totals[key] = map[string]int{"valid": 0, "revoked": 0, "expired": 0}
+	}
+	totals[key][status] = totals[key][status] + 1
+	if status != "valid" || certificate.ExpiresAt.IsZero() {
+		return
+	}
+	daysRemaining := daysUntil(certificate.ExpiresAt.UTC(), now.UTC())
+	if daysRemaining < 0 {
+		return
+	}
+	if soon[key] == nil {
+		soon[key] = map[string]int{"warning": 0, "critical": 0}
+	}
+	if collector.thresholds.Warning > 0 && daysRemaining <= collector.thresholds.Warning {
+		soon[key]["warning"] = soon[key]["warning"] + 1
+	}
+	if collector.thresholds.Critical > 0 && daysRemaining <= collector.thresholds.Critical {
+		soon[key]["critical"] = soon[key]["critical"] + 1
+	}
+}
+
 func (collector *certificateCollector) emitCertificateAggregationMetrics(ch chan<- prometheus.Metric, certificates []certs.Certificate, now time.Time) {
 	totals := make(map[string]map[string]int)
 	soon := make(map[string]map[string]int)
 	for _, certificate := range certificates {
-		vaultID, pki := extractVaultIDAndPKI(certificate.ID)
-		key := buildAggregationKey(vaultID, pki)
-		status := collector.statusLabel(certificate, now)
-		if _, ok := totals[key]; !ok {
-			totals[key] = map[string]int{"valid": 0, "revoked": 0, "expired": 0}
-		}
-		totals[key][status] = totals[key][status] + 1
-		if status != "valid" {
-			continue
-		}
-		if certificate.ExpiresAt.IsZero() {
-			continue
-		}
-		daysRemaining := daysUntil(certificate.ExpiresAt.UTC(), now.UTC())
-		if daysRemaining < 0 {
-			continue
-		}
-		if _, ok := soon[key]; !ok {
-			soon[key] = map[string]int{"warning": 0, "critical": 0}
-		}
-		if collector.thresholds.Warning > 0 && daysRemaining <= collector.thresholds.Warning {
-			soon[key]["warning"] = soon[key]["warning"] + 1
-		}
-		if collector.thresholds.Critical > 0 && daysRemaining <= collector.thresholds.Critical {
-			soon[key]["critical"] = soon[key]["critical"] + 1
-		}
+		collector.tallyAggregation(certificate, now, totals, soon)
 	}
 
 	keys := make([]string, 0, len(totals))
@@ -498,44 +557,17 @@ func (collector *certificateCollector) emitEnhancedMetrics(ch chan<- prometheus.
 	buckets := make(map[string]map[string]map[string]int)
 	for _, certificate := range certificates {
 		vaultID, pki := extractVaultIDAndPKI(certificate.ID)
-		if _, ok := buckets[vaultID]; !ok {
-			buckets[vaultID] = make(map[string]map[string]int)
-		}
-		if _, ok := buckets[vaultID][pki]; !ok {
-			buckets[vaultID][pki] = zeroExpiryBuckets()
-		}
 		if certificate.Revoked {
-			buckets[vaultID][pki]["revoked"]++
+			incCounter3(buckets, vaultID, pki, "revoked")
 			continue
 		}
 		if certificate.ExpiresAt.IsZero() {
 			continue
 		}
-		daysRemaining := daysUntil(certificate.ExpiresAt.UTC(), now.UTC())
-		if daysRemaining < 0 {
-			buckets[vaultID][pki]["expired"]++
-		} else if daysRemaining <= 7 {
-			buckets[vaultID][pki]["0-7d"]++
-		} else if daysRemaining <= 30 {
-			buckets[vaultID][pki]["7-30d"]++
-		} else if daysRemaining <= 90 {
-			buckets[vaultID][pki]["30-90d"]++
-		} else {
-			buckets[vaultID][pki]["90d+"]++
-		}
+		incCounter3(buckets, vaultID, pki, expiryBucketLabel(daysUntil(certificate.ExpiresAt.UTC(), now.UTC())))
 	}
-	vaultIDs := make([]string, 0, len(buckets))
-	for vaultID := range buckets {
-		vaultIDs = append(vaultIDs, vaultID)
-	}
-	sort.Strings(vaultIDs)
-	for _, vaultID := range vaultIDs {
-		pkis := make([]string, 0, len(buckets[vaultID]))
-		for pki := range buckets[vaultID] {
-			pkis = append(pkis, pki)
-		}
-		sort.Strings(pkis)
-		for _, pki := range pkis {
+	for _, vaultID := range sortedStringKeys(buckets) {
+		for _, pki := range sortedStringKeys(buckets[vaultID]) {
 			for _, bucket := range expiryBucketNames {
 				ch <- prometheus.MustNewConstMetric(expiryBucketDesc, prometheus.GaugeValue, float64(buckets[vaultID][pki][bucket]), vaultID, pki, bucket)
 			}

--- a/app/internal/metrics/certificate_collector.go
+++ b/app/internal/metrics/certificate_collector.go
@@ -19,6 +19,18 @@ import (
 
 const allLabelValue string = "__all__"
 
+// expiryBucketNames lists the expiry time buckets in emission order.
+var expiryBucketNames = []string{"0-7d", "7-30d", "30-90d", "90d+", "expired", "revoked"}
+
+// zeroExpiryBuckets returns a fresh counter map with every expiry bucket at 0.
+func zeroExpiryBuckets() map[string]int {
+	counts := make(map[string]int, len(expiryBucketNames))
+	for _, bucket := range expiryBucketNames {
+		counts[bucket] = 0
+	}
+	return counts
+}
+
 // perCertificateCardinalityWarnThreshold logs an extra warn when inventory size exceeds this while per_certificate is on.
 const perCertificateCardinalityWarnThreshold = 500
 
@@ -490,7 +502,7 @@ func (collector *certificateCollector) emitEnhancedMetrics(ch chan<- prometheus.
 			buckets[vaultID] = make(map[string]map[string]int)
 		}
 		if _, ok := buckets[vaultID][pki]; !ok {
-			buckets[vaultID][pki] = map[string]int{"0-7d": 0, "7-30d": 0, "30-90d": 0, "90d+": 0, "expired": 0, "revoked": 0}
+			buckets[vaultID][pki] = zeroExpiryBuckets()
 		}
 		if certificate.Revoked {
 			buckets[vaultID][pki]["revoked"]++
@@ -524,12 +536,12 @@ func (collector *certificateCollector) emitEnhancedMetrics(ch chan<- prometheus.
 		}
 		sort.Strings(pkis)
 		for _, pki := range pkis {
-			for _, bucket := range []string{"0-7d", "7-30d", "30-90d", "90d+", "expired", "revoked"} {
+			for _, bucket := range expiryBucketNames {
 				ch <- prometheus.MustNewConstMetric(expiryBucketDesc, prometheus.GaugeValue, float64(buckets[vaultID][pki][bucket]), vaultID, pki, bucket)
 			}
 		}
 	}
-	allBuckets := map[string]int{"0-7d": 0, "7-30d": 0, "30-90d": 0, "90d+": 0, "expired": 0, "revoked": 0}
+	allBuckets := zeroExpiryBuckets()
 	for vaultID := range buckets {
 		for pki := range buckets[vaultID] {
 			for bucket, count := range buckets[vaultID][pki] {
@@ -537,7 +549,7 @@ func (collector *certificateCollector) emitEnhancedMetrics(ch chan<- prometheus.
 			}
 		}
 	}
-	for _, bucket := range []string{"0-7d", "7-30d", "30-90d", "90d+", "expired", "revoked"} {
+	for _, bucket := range expiryBucketNames {
 		ch <- prometheus.MustNewConstMetric(expiryBucketDesc, prometheus.GaugeValue, float64(allBuckets[bucket]), allLabelValue, allLabelValue, bucket)
 	}
 }

--- a/app/internal/metrics/certificate_collector_enhanced.go
+++ b/app/internal/metrics/certificate_collector_enhanced.go
@@ -11,6 +11,18 @@ import (
 	"vcv/internal/certs"
 )
 
+// ageBucketNames lists the certificate age buckets in emission order.
+var ageBucketNames = []string{"0-30d", "30-90d", "90-180d", "180-365d", "1y+"}
+
+// zeroAgeBuckets returns a fresh counter map with every age bucket at 0.
+func zeroAgeBuckets() map[string]int {
+	counts := make(map[string]int, len(ageBucketNames))
+	for _, bucket := range ageBucketNames {
+		counts[bucket] = 0
+	}
+	return counts
+}
+
 // sortedStringKeys returns sorted keys from a string-keyed map.
 func sortedStringKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
@@ -155,7 +167,7 @@ func (collector *certificateCollector) emitAgeMetrics(ch chan<- prometheus.Metri
 			ageBuckets[vaultID] = make(map[string]map[string]int)
 		}
 		if _, ok := ageBuckets[vaultID][pki]; !ok {
-			ageBuckets[vaultID][pki] = map[string]int{"0-30d": 0, "30-90d": 0, "90-180d": 0, "180-365d": 0, "1y+": 0}
+			ageBuckets[vaultID][pki] = zeroAgeBuckets()
 		}
 		if ageDays <= 30 {
 			ageBuckets[vaultID][pki]["0-30d"]++
@@ -171,7 +183,7 @@ func (collector *certificateCollector) emitAgeMetrics(ch chan<- prometheus.Metri
 	}
 	for _, vaultID := range sortedStringKeys(ageBuckets) {
 		for _, pki := range sortedStringKeys(ageBuckets[vaultID]) {
-			for _, bucket := range []string{"0-30d", "30-90d", "90-180d", "180-365d", "1y+"} {
+			for _, bucket := range ageBucketNames {
 				ch <- prometheus.MustNewConstMetric(ageBucketDesc, prometheus.GaugeValue, float64(ageBuckets[vaultID][pki][bucket]), vaultID, pki, bucket)
 			}
 		}

--- a/app/internal/metrics/certificate_collector_enhanced.go
+++ b/app/internal/metrics/certificate_collector_enhanced.go
@@ -14,15 +14,6 @@ import (
 // ageBucketNames lists the certificate age buckets in emission order.
 var ageBucketNames = []string{"0-30d", "30-90d", "90-180d", "180-365d", "1y+"}
 
-// zeroAgeBuckets returns a fresh counter map with every age bucket at 0.
-func zeroAgeBuckets() map[string]int {
-	counts := make(map[string]int, len(ageBucketNames))
-	for _, bucket := range ageBucketNames {
-		counts[bucket] = 0
-	}
-	return counts
-}
-
 // sortedStringKeys returns sorted keys from a string-keyed map.
 func sortedStringKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
@@ -42,19 +33,26 @@ func matchesPattern(pattern, value string) bool {
 	return matched
 }
 
+// sanBucketLabel classifies a SAN count into a SAN bucket name.
+func sanBucketLabel(sanCount int) string {
+	switch {
+	case sanCount == 0:
+		return "0"
+	case sanCount <= 5:
+		return "1-5"
+	case sanCount <= 10:
+		return "6-10"
+	default:
+		return "11+"
+	}
+}
+
 // emitIssuerMetrics emits metrics grouped by certificate issuer CN.
 func (collector *certificateCollector) emitIssuerMetrics(ch chan<- prometheus.Metric, certificates []certs.Certificate) {
 	issuerCounts := make(map[string]map[string]map[string]int)
 	for _, certificate := range certificates {
 		vaultID, pki := extractVaultIDAndPKI(certificate.ID)
-		issuerCN := extractIssuerCN(certificate)
-		if _, ok := issuerCounts[vaultID]; !ok {
-			issuerCounts[vaultID] = make(map[string]map[string]int)
-		}
-		if _, ok := issuerCounts[vaultID][pki]; !ok {
-			issuerCounts[vaultID][pki] = make(map[string]int)
-		}
-		issuerCounts[vaultID][pki][issuerCN]++
+		incCounter3(issuerCounts, vaultID, pki, extractIssuerCN(certificate))
 	}
 	for _, vaultID := range sortedStringKeys(issuerCounts) {
 		for _, pki := range sortedStringKeys(issuerCounts[vaultID]) {
@@ -72,19 +70,9 @@ func (collector *certificateCollector) emitKeyTypeMetrics(ch chan<- prometheus.M
 	for _, certificate := range certificates {
 		vaultID, pki := extractVaultIDAndPKI(certificate.ID)
 		algorithm, keySize := extractKeyInfo(certificate)
-		if _, ok := keyTypeCounts[vaultID]; !ok {
-			keyTypeCounts[vaultID] = make(map[string]map[string]int)
-		}
-		if _, ok := keyTypeCounts[vaultID][pki]; !ok {
-			keyTypeCounts[vaultID][pki] = make(map[string]int)
-		}
-		keyTypeLabel := algorithm + "_" + keySize
-		keyTypeCounts[vaultID][pki][keyTypeLabel]++
+		incCounter3(keyTypeCounts, vaultID, pki, algorithm+"_"+keySize)
 		if isWeakKey(algorithm, keySize) {
-			if _, ok := weakKeyCounts[vaultID]; !ok {
-				weakKeyCounts[vaultID] = make(map[string]int)
-			}
-			weakKeyCounts[vaultID][pki]++
+			incCounter2(weakKeyCounts, vaultID, pki)
 		}
 	}
 	for _, vaultID := range sortedStringKeys(keyTypeCounts) {
@@ -99,11 +87,7 @@ func (collector *certificateCollector) emitKeyTypeMetrics(ch chan<- prometheus.M
 				}
 				ch <- prometheus.MustNewConstMetric(certsByKeyTypeDesc, prometheus.GaugeValue, float64(keyTypeCounts[vaultID][pki][keyType]), vaultID, pki, algorithm, keySize)
 			}
-			weakCount := 0
-			if counts, ok := weakKeyCounts[vaultID]; ok {
-				weakCount = counts[pki]
-			}
-			ch <- prometheus.MustNewConstMetric(weakKeysDesc, prometheus.GaugeValue, float64(weakCount), vaultID, pki)
+			ch <- prometheus.MustNewConstMetric(weakKeysDesc, prometheus.GaugeValue, float64(counter2At(weakKeyCounts, vaultID, pki)), vaultID, pki)
 		}
 	}
 }
@@ -115,35 +99,14 @@ func (collector *certificateCollector) emitSANMetrics(ch chan<- prometheus.Metri
 	for _, certificate := range certificates {
 		vaultID, pki := extractVaultIDAndPKI(certificate.ID)
 		sanCount := len(certificate.Sans)
-		if _, ok := sanCounts[vaultID]; !ok {
-			sanCounts[vaultID] = make(map[string]int)
-		}
 		if sanCount > 0 {
-			sanCounts[vaultID][pki]++
+			incCounter2(sanCounts, vaultID, pki)
 		}
-		if _, ok := sanBuckets[vaultID]; !ok {
-			sanBuckets[vaultID] = make(map[string]map[string]int)
-		}
-		if _, ok := sanBuckets[vaultID][pki]; !ok {
-			sanBuckets[vaultID][pki] = map[string]int{"0": 0, "1-5": 0, "6-10": 0, "11+": 0}
-		}
-		if sanCount == 0 {
-			sanBuckets[vaultID][pki]["0"]++
-		} else if sanCount <= 5 {
-			sanBuckets[vaultID][pki]["1-5"]++
-		} else if sanCount <= 10 {
-			sanBuckets[vaultID][pki]["6-10"]++
-		} else {
-			sanBuckets[vaultID][pki]["11+"]++
-		}
+		incCounter3(sanBuckets, vaultID, pki, sanBucketLabel(sanCount))
 	}
 	for _, vaultID := range sortedStringKeys(sanBuckets) {
 		for _, pki := range sortedStringKeys(sanBuckets[vaultID]) {
-			count := 0
-			if counts, ok := sanCounts[vaultID]; ok {
-				count = counts[pki]
-			}
-			ch <- prometheus.MustNewConstMetric(certsWithSansDesc, prometheus.GaugeValue, float64(count), vaultID, pki)
+			ch <- prometheus.MustNewConstMetric(certsWithSansDesc, prometheus.GaugeValue, float64(counter2At(sanCounts, vaultID, pki)), vaultID, pki)
 			for _, bucket := range []string{"0", "1-5", "6-10", "11+"} {
 				ch <- prometheus.MustNewConstMetric(sanCountBucketDesc, prometheus.GaugeValue, float64(sanBuckets[vaultID][pki][bucket]), vaultID, pki, bucket)
 			}
@@ -163,23 +126,7 @@ func (collector *certificateCollector) emitAgeMetrics(ch chan<- prometheus.Metri
 		if ageDays < 0 {
 			continue
 		}
-		if _, ok := ageBuckets[vaultID]; !ok {
-			ageBuckets[vaultID] = make(map[string]map[string]int)
-		}
-		if _, ok := ageBuckets[vaultID][pki]; !ok {
-			ageBuckets[vaultID][pki] = zeroAgeBuckets()
-		}
-		if ageDays <= 30 {
-			ageBuckets[vaultID][pki]["0-30d"]++
-		} else if ageDays <= 90 {
-			ageBuckets[vaultID][pki]["30-90d"]++
-		} else if ageDays <= 180 {
-			ageBuckets[vaultID][pki]["90-180d"]++
-		} else if ageDays <= 365 {
-			ageBuckets[vaultID][pki]["180-365d"]++
-		} else {
-			ageBuckets[vaultID][pki]["1y+"]++
-		}
+		incCounter3(ageBuckets, vaultID, pki, ageBucketLabel(ageDays))
 	}
 	for _, vaultID := range sortedStringKeys(ageBuckets) {
 		for _, pki := range sortedStringKeys(ageBuckets[vaultID]) {
@@ -187,6 +134,22 @@ func (collector *certificateCollector) emitAgeMetrics(ch chan<- prometheus.Metri
 				ch <- prometheus.MustNewConstMetric(ageBucketDesc, prometheus.GaugeValue, float64(ageBuckets[vaultID][pki][bucket]), vaultID, pki, bucket)
 			}
 		}
+	}
+}
+
+// ageBucketLabel classifies a certificate age in days into an age bucket name.
+func ageBucketLabel(ageDays int) string {
+	switch {
+	case ageDays <= 30:
+		return "0-30d"
+	case ageDays <= 90:
+		return "30-90d"
+	case ageDays <= 180:
+		return "90-180d"
+	case ageDays <= 365:
+		return "180-365d"
+	default:
+		return "1y+"
 	}
 }
 
@@ -205,69 +168,42 @@ func (collector *certificateCollector) emitRenewalMetrics(ch chan<- prometheus.M
 			continue
 		}
 		if ageDuration <= 24*time.Hour {
-			if _, ok := issued24h[vaultID]; !ok {
-				issued24h[vaultID] = make(map[string]int)
-			}
-			issued24h[vaultID][pki]++
+			incCounter2(issued24h, vaultID, pki)
 		}
 		if ageDuration <= 7*24*time.Hour {
-			if _, ok := issued7d[vaultID]; !ok {
-				issued7d[vaultID] = make(map[string]int)
-			}
-			issued7d[vaultID][pki]++
+			incCounter2(issued7d, vaultID, pki)
 		}
 		if ageDuration <= 30*24*time.Hour {
-			if _, ok := issued30d[vaultID]; !ok {
-				issued30d[vaultID] = make(map[string]int)
-			}
-			issued30d[vaultID][pki]++
+			incCounter2(issued30d, vaultID, pki)
 		}
 	}
-	allVaultIDs := make(map[string]bool)
-	for vaultID := range issued24h {
-		allVaultIDs[vaultID] = true
-	}
-	for vaultID := range issued7d {
-		allVaultIDs[vaultID] = true
-	}
-	for vaultID := range issued30d {
-		allVaultIDs[vaultID] = true
-	}
-	for _, vaultID := range sortedStringKeys(allVaultIDs) {
-		allPKIs := make(map[string]bool)
-		if pkis, ok := issued24h[vaultID]; ok {
-			for pki := range pkis {
-				allPKIs[pki] = true
-			}
-		}
-		if pkis, ok := issued7d[vaultID]; ok {
-			for pki := range pkis {
-				allPKIs[pki] = true
-			}
-		}
-		if pkis, ok := issued30d[vaultID]; ok {
-			for pki := range pkis {
-				allPKIs[pki] = true
-			}
-		}
-		for _, pki := range sortedStringKeys(allPKIs) {
-			count24h := 0
-			if counts, ok := issued24h[vaultID]; ok {
-				count24h = counts[pki]
-			}
-			count7d := 0
-			if counts, ok := issued7d[vaultID]; ok {
-				count7d = counts[pki]
-			}
-			count30d := 0
-			if counts, ok := issued30d[vaultID]; ok {
-				count30d = counts[pki]
-			}
-			ch <- prometheus.MustNewConstMetric(issuedLast24hDesc, prometheus.GaugeValue, float64(count24h), vaultID, pki)
-			ch <- prometheus.MustNewConstMetric(issuedLast7dDesc, prometheus.GaugeValue, float64(count7d), vaultID, pki)
-			ch <- prometheus.MustNewConstMetric(issuedLast30dDesc, prometheus.GaugeValue, float64(count30d), vaultID, pki)
+	for _, vaultID := range unionKeys(issued24h, issued7d, issued30d) {
+		for _, pki := range unionKeys(issued24h[vaultID], issued7d[vaultID], issued30d[vaultID]) {
+			ch <- prometheus.MustNewConstMetric(issuedLast24hDesc, prometheus.GaugeValue, float64(counter2At(issued24h, vaultID, pki)), vaultID, pki)
+			ch <- prometheus.MustNewConstMetric(issuedLast7dDesc, prometheus.GaugeValue, float64(counter2At(issued7d, vaultID, pki)), vaultID, pki)
+			ch <- prometheus.MustNewConstMetric(issuedLast30dDesc, prometheus.GaugeValue, float64(counter2At(issued30d, vaultID, pki)), vaultID, pki)
 		}
 	}
+}
+
+// isPinnedCertificate reports whether the certificate matches any pinned
+// pattern by common name, ID, or SAN.
+func isPinnedCertificate(pinnedPatterns map[string]bool, certificate certs.Certificate) bool {
+	values := []string{
+		strings.ToLower(strings.TrimSpace(certificate.CommonName)),
+		strings.ToLower(strings.TrimSpace(certificate.ID)),
+	}
+	for _, san := range certificate.Sans {
+		values = append(values, strings.ToLower(strings.TrimSpace(san)))
+	}
+	for pattern := range pinnedPatterns {
+		for _, value := range values {
+			if matchesPattern(pattern, value) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // emitPinnedCertificateMetrics emits per-certificate metrics only for pinned certificates.
@@ -277,37 +213,10 @@ func (collector *certificateCollector) emitPinnedCertificateMetrics(ch chan<- pr
 	}
 	pinnedMap := make(map[string]bool)
 	for _, pinned := range collector.pinnedCertificates {
-		normalized := strings.ToLower(strings.TrimSpace(pinned))
-		pinnedMap[normalized] = true
+		pinnedMap[strings.ToLower(strings.TrimSpace(pinned))] = true
 	}
 	for _, certificate := range certificates {
-		normalizedCN := strings.ToLower(strings.TrimSpace(certificate.CommonName))
-		normalizedID := strings.ToLower(strings.TrimSpace(certificate.ID))
-		isPinned := false
-		for pattern := range pinnedMap {
-			if matchesPattern(pattern, normalizedCN) || matchesPattern(pattern, normalizedID) {
-				isPinned = true
-				break
-			}
-		}
-		if !isPinned {
-			for _, san := range certificate.Sans {
-				normalizedSAN := strings.ToLower(strings.TrimSpace(san))
-				for pattern := range pinnedMap {
-					if matchesPattern(pattern, normalizedSAN) {
-						isPinned = true
-						break
-					}
-				}
-				if isPinned {
-					break
-				}
-			}
-		}
-		if !isPinned {
-			continue
-		}
-		if certificate.ExpiresAt.IsZero() {
+		if !isPinnedCertificate(pinnedMap, certificate) || certificate.ExpiresAt.IsZero() {
 			continue
 		}
 		vaultID, pki := extractVaultIDAndPKI(certificate.ID)

--- a/app/internal/middleware/middleware.go
+++ b/app/internal/middleware/middleware.go
@@ -100,6 +100,30 @@ func DefaultCORSConfig() CORSConfig {
 	}
 }
 
+// originAllowed reports whether origin is allowed by config, and whether the
+// match was a wildcard.
+func originAllowed(allowedOrigins []string, origin string) (bool, bool) {
+	for _, o := range allowedOrigins {
+		if o == "*" {
+			return true, true
+		}
+		if o == origin {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+// handlePreflight writes the CORS preflight response headers.
+func handlePreflight(w http.ResponseWriter, config CORSConfig) {
+	w.Header().Set("Access-Control-Allow-Methods", strings.Join(config.AllowedMethods, ", "))
+	w.Header().Set("Access-Control-Allow-Headers", strings.Join(config.AllowedHeaders, ", "))
+	if config.MaxAge > 0 {
+		w.Header().Set("Access-Control-Max-Age", strconv.Itoa(config.MaxAge))
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // CORS returns a CORS middleware with the given configuration.
 func CORS(config CORSConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -109,19 +133,7 @@ func CORS(config CORSConfig) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			allowed := false
-			wildcard := false
-			for _, o := range config.AllowedOrigins {
-				if o == "*" {
-					allowed = true
-					wildcard = true
-					break
-				}
-				if o == origin {
-					allowed = true
-					break
-				}
-			}
+			allowed, wildcard := originAllowed(config.AllowedOrigins, origin)
 			if !allowed {
 				next.ServeHTTP(w, r)
 				return
@@ -134,12 +146,7 @@ func CORS(config CORSConfig) func(http.Handler) http.Handler {
 				w.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
 			if r.Method == http.MethodOptions {
-				w.Header().Set("Access-Control-Allow-Methods", strings.Join(config.AllowedMethods, ", "))
-				w.Header().Set("Access-Control-Allow-Headers", strings.Join(config.AllowedHeaders, ", "))
-				if config.MaxAge > 0 {
-					w.Header().Set("Access-Control-Max-Age", strconv.Itoa(config.MaxAge))
-				}
-				w.WriteHeader(http.StatusNoContent)
+				handlePreflight(w, config)
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -209,6 +216,46 @@ func CSRFProtection(next http.Handler) http.Handler {
 	return CSRFProtectionWithTrust(false)(next)
 }
 
+// verifyUnsafeOrigin validates Origin/Referer headers for unsafe methods and
+// writes a 403 when the request must be rejected. Returns true when the
+// request may proceed.
+func verifyUnsafeOrigin(w http.ResponseWriter, r *http.Request, trustProxy bool) bool {
+	fetchSite := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")))
+	// Only block cross-site requests; allow same-site and same-origin.
+	// This is necessary for reverse proxy deployments where the browser
+	// may categorize requests as same-site rather than same-origin.
+	if fetchSite == "cross-site" {
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" {
+		if sameOrigin(origin, targetOrigin(r, trustProxy)) {
+			return true
+		}
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	referer := strings.TrimSpace(r.Header.Get("Referer"))
+	if referer != "" {
+		parsed, err := url.Parse(referer)
+		if err == nil {
+			refererOrigin := parsed.Scheme + "://" + parsed.Host
+			if sameOrigin(refererOrigin, targetOrigin(r, trustProxy)) {
+				return true
+			}
+		}
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	// Cookie-bearing unsafe methods without Origin/Referer are likely
+	// browser session CSRF; allow only cookieless non-browser clients.
+	if hasCookies(r) {
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
 // CSRFProtectionWithTrust returns CSRF middleware. When trustProxy is true,
 // target origin prefers X-Forwarded-Host / X-Forwarded-Proto (for reverse proxies
 // that overwrite those headers). When false, only r.Host and TLS/http are used.
@@ -220,40 +267,7 @@ func CSRFProtectionWithTrust(trustProxy bool) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			fetchSite := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")))
-			// Only block cross-site requests; allow same-site and same-origin.
-			// This is necessary for reverse proxy deployments where the browser
-			// may categorize requests as same-site rather than same-origin.
-			if fetchSite == "cross-site" {
-				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-				return
-			}
-			origin := strings.TrimSpace(r.Header.Get("Origin"))
-			if origin != "" {
-				if sameOrigin(origin, targetOrigin(r, trustProxy)) {
-					next.ServeHTTP(w, r)
-					return
-				}
-				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-				return
-			}
-			referer := strings.TrimSpace(r.Header.Get("Referer"))
-			if referer != "" {
-				parsed, err := url.Parse(referer)
-				if err == nil {
-					refererOrigin := parsed.Scheme + "://" + parsed.Host
-					if sameOrigin(refererOrigin, targetOrigin(r, trustProxy)) {
-						next.ServeHTTP(w, r)
-						return
-					}
-				}
-				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-				return
-			}
-			// Cookie-bearing unsafe methods without Origin/Referer are likely
-			// browser session CSRF; allow only cookieless non-browser clients.
-			if hasCookies(r) {
-				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			if !verifyUnsafeOrigin(w, r, trustProxy) {
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/app/internal/vault/disabled.go
+++ b/app/internal/vault/disabled.go
@@ -34,6 +34,7 @@ func (c *disabledClient) GetIntermediateCA(_ context.Context, _ string) (certs.D
 
 // InvalidateCache is a no-op: the disabled client holds no cache.
 func (c *disabledClient) InvalidateCache() {
+	// No-op: nothing is cached.
 }
 
 func (c *disabledClient) ListCertificates(_ context.Context) ([]certs.Certificate, error) {
@@ -42,4 +43,5 @@ func (c *disabledClient) ListCertificates(_ context.Context) ([]certs.Certificat
 
 // Shutdown is a no-op: the disabled client holds no resources to release.
 func (c *disabledClient) Shutdown() {
+	// No-op: nothing to shut down.
 }

--- a/app/internal/vault/disabled.go
+++ b/app/internal/vault/disabled.go
@@ -32,6 +32,7 @@ func (c *disabledClient) GetIntermediateCA(_ context.Context, _ string) (certs.D
 	return certs.DetailedCertificate{}, ErrVaultNotConfigured
 }
 
+// InvalidateCache is a no-op: the disabled client holds no cache.
 func (c *disabledClient) InvalidateCache() {
 }
 
@@ -39,5 +40,6 @@ func (c *disabledClient) ListCertificates(_ context.Context) ([]certs.Certificat
 	return []certs.Certificate{}, nil
 }
 
+// Shutdown is a no-op: the disabled client holds no resources to release.
 func (c *disabledClient) Shutdown() {
 }

--- a/app/internal/vault/multi.go
+++ b/app/internal/vault/multi.go
@@ -176,66 +176,37 @@ func (c *multiClient) InvalidateCache() {
 	}
 }
 
-func (c *multiClient) ListCertificates(ctx context.Context) ([]certs.Certificate, error) {
-	active := c.activeVaultIDs()
-	if len(active) == 0 {
-		logger.Get().Debug().Msg("no vault instances configured for certificate listing")
-		return []certs.Certificate{}, ErrVaultNotConfigured
-	}
+// certListResult carries the per-vault outcome of a certificate listing.
+type certListResult struct {
+	vaultID      string
+	certificates []certs.Certificate
+	err          error
+}
 
+// listFromVault fetches certificates from a single vault instance, logging
+// the outcome.
+func (c *multiClient) listFromVault(ctx context.Context, vaultID string, client Client) certListResult {
 	logger.Get().Debug().
-		Strs("vault_ids", active).
-		Int("vault_count", len(active)).
-		Msg("listing certificates from all vault instances")
-
-	type result struct {
-		vaultID      string
-		certificates []certs.Certificate
-		err          error
+		Str("vault_id", vaultID).
+		Msg("fetching certificates from vault instance")
+	certificates, err := client.ListCertificates(ctx)
+	if err != nil {
+		logger.Get().Error().
+			Str("vault_id", vaultID).
+			Err(err).
+			Msg("failed to fetch certificates from vault instance")
+		return certListResult{vaultID: vaultID, certificates: []certs.Certificate{}, err: err}
 	}
-	resultChan := make(chan result, len(active))
-	var wg sync.WaitGroup
+	logger.Get().Debug().
+		Str("vault_id", vaultID).
+		Int("certificate_count", len(certificates)).
+		Msg("successfully fetched certificates from vault instance")
+	return certListResult{vaultID: vaultID, certificates: certificates, err: nil}
+}
 
-	for _, vaultID := range active {
-		client := c.clientsByVault[vaultID]
-		if client == nil {
-			logger.Get().Error().
-				Str("vault_id", vaultID).
-				Msg("missing vault client for certificate listing")
-			resultChan <- result{vaultID: vaultID, certificates: []certs.Certificate{}, err: fmt.Errorf(errMissingVaultClient, vaultID)}
-			continue
-		}
-		wg.Add(1)
-		go func(id string, cl Client) {
-			defer wg.Done()
-			logger.Get().Debug().
-				Str("vault_id", id).
-				Msg("fetching certificates from vault instance")
-
-			var certificates []certs.Certificate
-			var err error
-			certificates, err = cl.ListCertificates(ctx)
-			if err != nil {
-				logger.Get().Error().
-					Str("vault_id", id).
-					Err(err).
-					Msg("failed to fetch certificates from vault instance")
-				resultChan <- result{vaultID: id, certificates: []certs.Certificate{}, err: err}
-				return
-			}
-
-			logger.Get().Debug().
-				Str("vault_id", id).
-				Int("certificate_count", len(certificates)).
-				Msg("successfully fetched certificates from vault instance")
-
-			resultChan <- result{vaultID: id, certificates: certificates, err: nil}
-		}(vaultID, client)
-	}
-	go func() {
-		wg.Wait()
-		close(resultChan)
-	}()
+// collectListResults drains the result channel, merging successful listings
+// (with vault-prefixed IDs) and tracking the last failure.
+func collectListResults(resultChan <-chan certListResult) ([]certs.Certificate, int, error) {
 	all := make([]certs.Certificate, 0)
 	successCount := 0
 	var lastError error
@@ -251,6 +222,44 @@ func (c *multiClient) ListCertificates(ctx context.Context) ([]certs.Certificate
 			all = append(all, prefixed)
 		}
 	}
+	return all, successCount, lastError
+}
+
+func (c *multiClient) ListCertificates(ctx context.Context) ([]certs.Certificate, error) {
+	active := c.activeVaultIDs()
+	if len(active) == 0 {
+		logger.Get().Debug().Msg("no vault instances configured for certificate listing")
+		return []certs.Certificate{}, ErrVaultNotConfigured
+	}
+
+	logger.Get().Debug().
+		Strs("vault_ids", active).
+		Int("vault_count", len(active)).
+		Msg("listing certificates from all vault instances")
+
+	resultChan := make(chan certListResult, len(active))
+	var wg sync.WaitGroup
+
+	for _, vaultID := range active {
+		client := c.clientsByVault[vaultID]
+		if client == nil {
+			logger.Get().Error().
+				Str("vault_id", vaultID).
+				Msg("missing vault client for certificate listing")
+			resultChan <- certListResult{vaultID: vaultID, certificates: []certs.Certificate{}, err: fmt.Errorf(errMissingVaultClient, vaultID)}
+			continue
+		}
+		wg.Add(1)
+		go func(id string, cl Client) {
+			defer wg.Done()
+			resultChan <- c.listFromVault(ctx, id, cl)
+		}(vaultID, client)
+	}
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+	all, successCount, lastError := collectListResults(resultChan)
 
 	logger.Get().Debug().
 		Int("total_certificates", len(all)).

--- a/app/internal/vault/multi.go
+++ b/app/internal/vault/multi.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -11,6 +12,14 @@ import (
 	"vcv/internal/certs"
 	"vcv/internal/config"
 	"vcv/internal/logger"
+)
+
+const (
+	// errMissingVaultClient is the format used when an operation targets a
+	// vault ID that has no registered client.
+	errMissingVaultClient = "missing vault client for %s"
+	// errInvalidCertID is returned when a certificate ID cannot be parsed.
+	errInvalidCertID = "invalid certificate id"
 )
 
 type multiClient struct {
@@ -84,7 +93,7 @@ func (c *multiClient) CheckConnection(ctx context.Context) error {
 			logger.Get().Error().
 				Str("vault_id", vaultID).
 				Msg("missing vault client for connection check")
-			return fmt.Errorf("missing vault client for %s", vaultID)
+			return fmt.Errorf(errMissingVaultClient, vaultID)
 		}
 
 		logger.Get().Debug().
@@ -115,7 +124,7 @@ func (c *multiClient) GetCertificateDetails(ctx context.Context, serialNumber st
 	}
 	client := c.clientsByVault[vaultID]
 	if client == nil {
-		return certs.DetailedCertificate{}, fmt.Errorf("missing vault client for %s", vaultID)
+		return certs.DetailedCertificate{}, fmt.Errorf(errMissingVaultClient, vaultID)
 	}
 	details, err := client.GetCertificateDetails(ctx, mountSerial)
 	if err != nil {
@@ -132,7 +141,7 @@ func (c *multiClient) GetCertificatePEM(ctx context.Context, serialNumber string
 	}
 	client := c.clientsByVault[vaultID]
 	if client == nil {
-		return certs.PEMResponse{}, fmt.Errorf("missing vault client for %s", vaultID)
+		return certs.PEMResponse{}, fmt.Errorf(errMissingVaultClient, vaultID)
 	}
 	return client.GetCertificatePEM(ctx, mountSerial)
 }
@@ -144,7 +153,7 @@ func (c *multiClient) GetIntermediateCA(ctx context.Context, mount string) (cert
 	}
 	client := c.clientsByVault[vaultID]
 	if client == nil {
-		return certs.DetailedCertificate{}, fmt.Errorf("missing vault client for %s", vaultID)
+		return certs.DetailedCertificate{}, fmt.Errorf(errMissingVaultClient, vaultID)
 	}
 	details, err := client.GetIntermediateCA(ctx, pureMount)
 	if err != nil {
@@ -193,7 +202,7 @@ func (c *multiClient) ListCertificates(ctx context.Context) ([]certs.Certificate
 			logger.Get().Error().
 				Str("vault_id", vaultID).
 				Msg("missing vault client for certificate listing")
-			resultChan <- result{vaultID: vaultID, certificates: []certs.Certificate{}, err: fmt.Errorf("missing vault client for %s", vaultID)}
+			resultChan <- result{vaultID: vaultID, certificates: []certs.Certificate{}, err: fmt.Errorf(errMissingVaultClient, vaultID)}
 			continue
 		}
 		wg.Add(1)
@@ -286,7 +295,7 @@ func (c *multiClient) ListCertificatesEnvelope(ctx context.Context) ([]certs.Cer
 	for _, vaultID := range active {
 		client := c.clientsByVault[vaultID]
 		if client == nil {
-			resultChan <- result{vaultID: vaultID, err: fmt.Errorf("missing vault client for %s", vaultID)}
+			resultChan <- result{vaultID: vaultID, err: fmt.Errorf(errMissingVaultClient, vaultID)}
 			continue
 		}
 		wg.Add(1)
@@ -337,7 +346,7 @@ func (c *multiClient) ListCertificatesByVault(ctx context.Context) []ListCertifi
 	for _, vaultID := range active {
 		client := c.clientsByVault[vaultID]
 		if client == nil {
-			results = append(results, ListCertificatesByVaultResult{VaultID: vaultID, Certificates: []certs.Certificate{}, Duration: 0, ListError: fmt.Errorf("missing vault client for %s", vaultID)})
+			results = append(results, ListCertificatesByVaultResult{VaultID: vaultID, Certificates: []certs.Certificate{}, Duration: 0, ListError: fmt.Errorf(errMissingVaultClient, vaultID)})
 			continue
 		}
 		start := time.Now()
@@ -394,16 +403,16 @@ func parseCompositeCertificateID(orderedVaultIDs []string, value string) (string
 		vaultID := strings.TrimSpace(parts[0])
 		mountSerial := strings.TrimSpace(parts[1])
 		if vaultID == "" || mountSerial == "" {
-			return "", "", fmt.Errorf("invalid certificate id")
+			return "", "", errors.New(errInvalidCertID)
 		}
 		return vaultID, mountSerial, nil
 	}
 	if len(orderedVaultIDs) == 0 {
-		return "", "", fmt.Errorf("invalid certificate id")
+		return "", "", errors.New(errInvalidCertID)
 	}
 	mountSerial := strings.TrimSpace(value)
 	if mountSerial == "" {
-		return "", "", fmt.Errorf("invalid certificate id")
+		return "", "", errors.New(errInvalidCertID)
 	}
 	return orderedVaultIDs[0], mountSerial, nil
 }

--- a/app/internal/vault/real.go
+++ b/app/internal/vault/real.go
@@ -24,6 +24,10 @@ import (
 
 const cacheVersion = "v2"
 
+// errParseCertificate is the format used when a certificate PEM cannot be
+// parsed for a given serial and mount.
+const errParseCertificate = "failed to parse certificate %s in mount %s: %w"
+
 type realClient struct {
 	client   *api.Client
 	mounts   []string
@@ -356,7 +360,7 @@ func (c *realClient) readCertificateFromMount(ctx context.Context, mount, serial
 
 	x509Certificate, parseError := x509.ParseCertificate(block.Bytes)
 	if parseError != nil {
-		return certs.Certificate{}, fmt.Errorf("failed to parse certificate %s in mount %s: %w", serial, mount, parseError)
+		return certs.Certificate{}, fmt.Errorf(errParseCertificate, serial, mount, parseError)
 	}
 
 	subjectAlternativeNames := buildSANs(x509Certificate)
@@ -404,7 +408,7 @@ func (c *realClient) fetchCertificatePEM(ctx context.Context, mount string, seri
 		return "", fmt.Errorf("failed to decode PEM for certificate %s in mount %s", serial, mount)
 	}
 	if _, parseError := x509.ParseCertificate(block.Bytes); parseError != nil {
-		return "", fmt.Errorf("failed to parse certificate %s in mount %s: %w", serial, mount, parseError)
+		return "", fmt.Errorf(errParseCertificate, serial, mount, parseError)
 	}
 	return certificatePEM, nil
 }
@@ -463,7 +467,7 @@ func (c *realClient) GetCertificateDetails(ctx context.Context, serialNumber str
 	block, _ := pem.Decode([]byte(certificatePEM))
 	x509Certificate, parseError := x509.ParseCertificate(block.Bytes)
 	if parseError != nil {
-		return certs.DetailedCertificate{}, fmt.Errorf("failed to parse certificate %s in mount %s: %w", serial, mount, parseError)
+		return certs.DetailedCertificate{}, fmt.Errorf(errParseCertificate, serial, mount, parseError)
 	}
 
 	// Calculate fingerprints

--- a/app/internal/vault/real.go
+++ b/app/internal/vault/real.go
@@ -378,6 +378,55 @@ func (c *realClient) readCertificateFromMount(ctx context.Context, mount, serial
 	}, nil
 }
 
+// fetchCertificatePEM reads the certificate field for a serial from Vault
+// and returns the PEM payload.
+func (c *realClient) fetchCertificatePEM(ctx context.Context, mount string, serial string) (string, error) {
+	path := fmt.Sprintf("%s/cert/%s", mount, serial)
+	secret, err := c.client.Logical().ReadWithContext(ctx, path)
+	if err != nil {
+		logger.Get().Error().
+			Str("vault_addr", c.addr).
+			Str("mount", mount).
+			Str("serial", serial).
+			Err(err).
+			Msg("failed to read certificate from vault")
+		return "", fmt.Errorf("failed to read certificate %s from mount %s: %w", serial, mount, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return "", fmt.Errorf("certificate %s not found in mount %s", serial, mount)
+	}
+	certificatePEM, ok := secret.Data["certificate"].(string)
+	if !ok || certificatePEM == "" {
+		return "", fmt.Errorf("certificate field missing for %s in mount %s", serial, mount)
+	}
+	block, _ := pem.Decode([]byte(certificatePEM))
+	if block == nil {
+		return "", fmt.Errorf("failed to decode PEM for certificate %s in mount %s", serial, mount)
+	}
+	if _, parseError := x509.ParseCertificate(block.Bytes); parseError != nil {
+		return "", fmt.Errorf("failed to parse certificate %s in mount %s: %w", serial, mount, parseError)
+	}
+	return certificatePEM, nil
+}
+
+// extKeyUsageLabels maps extended key usages to human-readable labels.
+func extKeyUsageLabels(certificate *x509.Certificate) []string {
+	var usage []string
+	for _, extUsage := range certificate.ExtKeyUsage {
+		switch extUsage {
+		case x509.ExtKeyUsageServerAuth:
+			usage = append(usage, "Server Auth")
+		case x509.ExtKeyUsageClientAuth:
+			usage = append(usage, "Client Auth")
+		case x509.ExtKeyUsageCodeSigning:
+			usage = append(usage, "Code Signing")
+		case x509.ExtKeyUsageEmailProtection:
+			usage = append(usage, "Email Protection")
+		}
+	}
+	return usage
+}
+
 func (c *realClient) GetCertificateDetails(ctx context.Context, serialNumber string) (certs.DetailedCertificate, error) {
 	// Parse mount and serial from the prefixed ID
 	mount, serial, err := c.parseMountAndSerial(serialNumber)
@@ -406,31 +455,12 @@ func (c *realClient) GetCertificateDetails(ctx context.Context, serialNumber str
 		}
 	}
 
-	path := fmt.Sprintf("%s/cert/%s", mount, serial)
-	secret, err := c.client.Logical().ReadWithContext(ctx, path)
+	certificatePEM, err := c.fetchCertificatePEM(ctx, mount, serial)
 	if err != nil {
-		logger.Get().Error().
-			Str("vault_addr", c.addr).
-			Str("mount", mount).
-			Str("serial", serial).
-			Err(err).
-			Msg("failed to read certificate from vault")
-		return certs.DetailedCertificate{}, fmt.Errorf("failed to read certificate %s from mount %s: %w", serial, mount, err)
-	}
-	if secret == nil || secret.Data == nil {
-		return certs.DetailedCertificate{}, fmt.Errorf("certificate %s not found in mount %s", serial, mount)
-	}
-
-	certificatePEM, ok := secret.Data["certificate"].(string)
-	if !ok || certificatePEM == "" {
-		return certs.DetailedCertificate{}, fmt.Errorf("certificate field missing for %s in mount %s", serial, mount)
+		return certs.DetailedCertificate{}, err
 	}
 
 	block, _ := pem.Decode([]byte(certificatePEM))
-	if block == nil {
-		return certs.DetailedCertificate{}, fmt.Errorf("failed to decode PEM for certificate %s in mount %s", serial, mount)
-	}
-
 	x509Certificate, parseError := x509.ParseCertificate(block.Bytes)
 	if parseError != nil {
 		return certs.DetailedCertificate{}, fmt.Errorf("failed to parse certificate %s in mount %s: %w", serial, mount, parseError)
@@ -441,23 +471,7 @@ func (c *realClient) GetCertificateDetails(ctx context.Context, serialNumber str
 	sha256Fingerprint := sha256.Sum256(x509Certificate.Raw)
 
 	subjectAlternativeNames := buildSANs(x509Certificate)
-
-	// Extract key usage
-	var usage []string
-	if len(x509Certificate.ExtKeyUsage) > 0 {
-		for _, extUsage := range x509Certificate.ExtKeyUsage {
-			switch extUsage {
-			case x509.ExtKeyUsageServerAuth:
-				usage = append(usage, "Server Auth")
-			case x509.ExtKeyUsageClientAuth:
-				usage = append(usage, "Client Auth")
-			case x509.ExtKeyUsageCodeSigning:
-				usage = append(usage, "Code Signing")
-			case x509.ExtKeyUsageEmailProtection:
-				usage = append(usage, "Email Protection")
-			}
-		}
-	}
+	usage := extKeyUsageLabels(x509Certificate)
 
 	// Get revoked status
 	revokedSet, err := c.fetchRevokedSerialsFromMount(ctx, mount)

--- a/app/internal/vault/real_client_test.go
+++ b/app/internal/vault/real_client_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -31,6 +32,42 @@ import (
 
 type vaultTestServerState struct {
 	certificatePEM string
+}
+
+// writeVaultTestJSON writes a JSON response with the given status.
+func writeVaultTestJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// isVaultListRequest reports whether the request is a Vault LIST of path.
+func isVaultListRequest(r *http.Request, path string) bool {
+	if r.URL.Path != path {
+		return false
+	}
+	return r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")
+}
+
+// newVaultHTTPHandler returns a minimal Vault PKI handler serving the given
+// certificate PEM for the listed serials and a cert list with the given keys.
+func newVaultHTTPHandler(certificatePEM string, listKeys []string, serials []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/sys/health":
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"initialized": true, "sealed": false})
+		case r.URL.Path == "/v1/auth/token/lookup-self":
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"data": map[string]any{"id": "token"}})
+		case isVaultListRequest(r, "/v1/pki/certs"):
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"data": map[string]any{"keys": listKeys}})
+		case isVaultListRequest(r, "/v1/pki/certs/revoked"):
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"data": map[string]any{"keys": []string{"bb"}}})
+		case r.Method == http.MethodGet && slices.Contains(serials, strings.TrimPrefix(r.URL.Path, "/v1/pki/cert/")):
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"data": map[string]any{"certificate": certificatePEM}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
 }
 
 func newVaultTestCertificatePEM(t *testing.T) string {
@@ -64,36 +101,7 @@ func newVaultTestCertificatePEM(t *testing.T) string {
 }
 
 func newVaultTestServer(state vaultTestServerState) *httptest.Server {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/v1/sys/health" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"initialized": true, "sealed": false})
-			return
-		}
-		if r.URL.Path == "/v1/auth/token/lookup-self" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "token"}})
-			return
-		}
-		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"aa", "bb"}}})
-			return
-		}
-		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs/revoked" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"bb"}}})
-			return
-		}
-		if r.Method == http.MethodGet && (r.URL.Path == "/v1/pki/cert/aa" || r.URL.Path == "/v1/pki/cert/bb" || r.URL.Path == "/v1/pki/cert/ca") {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"certificate": state.certificatePEM}})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	})
-	return httptest.NewServer(handler)
+	return httptest.NewServer(newVaultHTTPHandler(state.certificatePEM, []string{"aa", "bb"}, []string{"aa", "bb", "ca"}))
 }
 
 func newRealClientForTest(t *testing.T, serverURL string, mounts []string) *realClient {
@@ -105,6 +113,27 @@ func newRealClientForTest(t *testing.T, serverURL string, mounts []string) *real
 	}
 	apiClient.SetToken("token")
 	return &realClient{client: apiClient, mounts: mounts, addr: serverURL, cache: cache.New(5 * time.Minute), stopChan: make(chan struct{})}
+}
+
+// assertClientCreation runs NewClientFromConfig and asserts the expected outcome.
+func assertClientCreation(t *testing.T, cfg config.VaultConfig, expectError bool) {
+	t.Helper()
+	client, err := NewClientFromConfig(cfg)
+	if expectError {
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if client != nil {
+			t.Fatalf("expected nil client")
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client == nil {
+		t.Fatalf("expected client")
+	}
 }
 
 func TestNewClientFromConfig_Validation(t *testing.T) {
@@ -119,52 +148,14 @@ func TestNewClientFromConfig_Validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := NewClientFromConfig(tt.cfg)
-			if tt.expectError {
-				if err == nil {
-					t.Fatalf("expected error")
-				}
-				if client != nil {
-					t.Fatalf("expected nil client")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-			if client == nil {
-				t.Fatalf("expected client")
-			}
+			assertClientCreation(t, tt.cfg, tt.expectError)
 		})
 	}
 }
 
 func TestNewClientFromConfig_TLSInsecure_AllowsTLSWithoutCA(t *testing.T) {
 	certificatePEM := newVaultTestCertificatePEM(t)
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/v1/sys/health" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"initialized": true, "sealed": false})
-			return
-		}
-		if r.URL.Path == "/v1/auth/token/lookup-self" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "token"}})
-			return
-		}
-		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"aa", "bb"}}})
-			return
-		}
-		if r.Method == http.MethodGet && (r.URL.Path == "/v1/pki/cert/aa" || r.URL.Path == "/v1/pki/cert/bb") {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"certificate": certificatePEM}})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
+	server := httptest.NewTLSServer(newVaultHTTPHandler(certificatePEM, []string{"aa", "bb"}, []string{"aa", "bb"}))
 	defer server.Close()
 	c, err := NewClientFromConfig(config.VaultConfig{Addr: server.URL, ReadToken: "token", PKIMounts: []string{"pki"}, TLSInsecure: true})
 	if err != nil {
@@ -177,30 +168,7 @@ func TestNewClientFromConfig_TLSInsecure_AllowsTLSWithoutCA(t *testing.T) {
 
 func TestNewClientFromConfig_TLSCACert_AllowsTLSWithCA(t *testing.T) {
 	certificatePEM := newVaultTestCertificatePEM(t)
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/v1/sys/health" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"initialized": true, "sealed": false})
-			return
-		}
-		if r.URL.Path == "/v1/auth/token/lookup-self" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "token"}})
-			return
-		}
-		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"aa"}}})
-			return
-		}
-		if r.Method == http.MethodGet && r.URL.Path == "/v1/pki/cert/aa" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"certificate": certificatePEM}})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
+	server := httptest.NewTLSServer(newVaultHTTPHandler(certificatePEM, []string{"aa"}, []string{"aa"}))
 	defer server.Close()
 	serverURL, parseErr := url.Parse(server.URL)
 	if parseErr != nil {
@@ -230,30 +198,7 @@ func TestNewClientFromConfig_TLSCACert_BadPathReturnsError(t *testing.T) {
 
 func TestNewClientFromConfig_TLSCACertBase64_AllowsTLSWithCA(t *testing.T) {
 	certificatePEM := newVaultTestCertificatePEM(t)
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/v1/sys/health" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"initialized": true, "sealed": false})
-			return
-		}
-		if r.URL.Path == "/v1/auth/token/lookup-self" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "token"}})
-			return
-		}
-		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"aa"}}})
-			return
-		}
-		if r.Method == http.MethodGet && r.URL.Path == "/v1/pki/cert/aa" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"certificate": certificatePEM}})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
+	server := httptest.NewTLSServer(newVaultHTTPHandler(certificatePEM, []string{"aa"}, []string{"aa"}))
 	defer server.Close()
 	serverURL, parseErr := url.Parse(server.URL)
 	if parseErr != nil {
@@ -278,6 +223,27 @@ func TestNewClientFromConfig_TLSCACertBase64_InvalidBase64ReturnsError(t *testin
 	}
 }
 
+// assertParseMountAndSerial asserts the parse outcome for one test case.
+func assertParseMountAndSerial(t *testing.T, client *realClient, value string, expectedMnt string, expectedSer string, expectErr bool) {
+	t.Helper()
+	mount, serial, err := client.parseMountAndSerial(value)
+	if expectErr {
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mount != expectedMnt {
+		t.Fatalf("expected mount %q, got %q", expectedMnt, mount)
+	}
+	if serial != expectedSer {
+		t.Fatalf("expected serial %q, got %q", expectedSer, serial)
+	}
+}
+
 func TestParseMountAndSerial(t *testing.T) {
 	client := &realClient{mounts: []string{"pki", "pki_dev"}}
 	tests := []struct {
@@ -293,22 +259,7 @@ func TestParseMountAndSerial(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mount, serial, err := client.parseMountAndSerial(tt.value)
-			if tt.expectErr {
-				if err == nil {
-					t.Fatalf("expected error")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if mount != tt.expectedMnt {
-				t.Fatalf("expected mount %q, got %q", tt.expectedMnt, mount)
-			}
-			if serial != tt.expectedSer {
-				t.Fatalf("expected serial %q, got %q", tt.expectedSer, serial)
-			}
+			assertParseMountAndSerial(t, client, tt.value, tt.expectedMnt, tt.expectedSer, tt.expectErr)
 		})
 	}
 	clientNoMounts := &realClient{mounts: []string{}}
@@ -377,23 +328,7 @@ func TestRealClient_ListCertificates_CacheHit(t *testing.T) {
 	var requestCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"aa", "bb"}}})
-			return
-		}
-		if (r.Method == "LIST" || (r.Method == http.MethodGet && r.URL.Query().Get("list") == "true")) && r.URL.Path == "/v1/pki/certs/revoked" {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"keys": []string{"bb"}}})
-			return
-		}
-		if r.Method == http.MethodGet && (r.URL.Path == "/v1/pki/cert/aa" || r.URL.Path == "/v1/pki/cert/bb") {
-			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"certificate": certificatePEM}})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
+		newVaultHTTPHandler(certificatePEM, []string{"aa", "bb"}, []string{"aa", "bb"}).ServeHTTP(w, r)
 	}))
 	defer server.Close()
 
@@ -612,6 +547,18 @@ func TestRealClient_CacheSize(t *testing.T) {
 	}
 }
 
+// assertLogContains asserts that the captured log output contains every
+// expected substring.
+func assertLogContains(t *testing.T, buf *bytes.Buffer, expected []string) {
+	t.Helper()
+	output := buf.String()
+	for _, want := range expected {
+		if !strings.Contains(output, want) {
+			t.Errorf("Expected %q in log, got: %s", want, output)
+		}
+	}
+}
+
 // TestRealClient_Logging tests that logging works correctly for vault operations
 func TestRealClient_Logging(t *testing.T) {
 	// Setup logger to capture output
@@ -622,37 +569,13 @@ func TestRealClient_Logging(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/sys/health":
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(map[string]any{
-				"initialized": true,
-				"sealed":      false,
-				"version":     "1.12.0",
-			}); err != nil {
-				t.Fatalf("failed to encode health response: %v", err)
-			}
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"initialized": true, "sealed": false, "version": "1.12.0"})
 		case "/v1/auth/token/lookup-self":
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{"id": "token"},
-			}); err != nil {
-				t.Fatalf("failed to encode token response: %v", err)
-			}
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"data": map[string]any{"id": "token"}})
 		case "/v1/pki/certs":
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string][]string{"keys": {"01"}},
-			}); err != nil {
-				t.Fatalf("failed to encode certs response: %v", err)
-			}
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"data": map[string][]string{"keys": {"01"}}})
 		case "/v1/pki/cert/01":
-			w.Header().Set("Content-Type", "application/json")
-			if err := json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]string{
-					"certificate": newVaultTestCertificatePEM(t),
-				},
-			}); err != nil {
-				t.Fatalf("failed to encode cert response: %v", err)
-			}
+			writeVaultTestJSON(w, http.StatusOK, map[string]any{"data": map[string]string{"certificate": newVaultTestCertificatePEM(t)}})
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -667,14 +590,7 @@ func TestRealClient_Logging(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	output := buf.String()
-	if !strings.Contains(output, "checking vault connection") {
-		t.Errorf("Expected connection check log, got: %s", output)
-	}
-	if !strings.Contains(output, "vault connection successful") {
-		t.Errorf("Expected successful connection log, got: %s", output)
-	}
+	assertLogContains(t, &buf, []string{"checking vault connection", "vault connection successful"})
 
 	// Test ListCertificates logging
 	buf.Reset()
@@ -682,20 +598,12 @@ func TestRealClient_Logging(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	output = buf.String()
-	if !strings.Contains(output, "listing certificates from vault mounts") {
-		t.Errorf("Expected listing logs, got: %s", output)
-	}
-	if !strings.Contains(output, "listing certificates from mount") {
-		t.Errorf("Expected mount listing logs, got: %s", output)
-	}
-	if !strings.Contains(output, "successfully listed certificates from mount") {
-		t.Errorf("Expected success logs, got: %s", output)
-	}
-	if !strings.Contains(output, "completed certificate listing and cached result") {
-		t.Errorf("Expected completion logs, got: %s", output)
-	}
+	assertLogContains(t, &buf, []string{
+		"listing certificates from vault mounts",
+		"listing certificates from mount",
+		"successfully listed certificates from mount",
+		"completed certificate listing and cached result",
+	})
 
 	// Test GetCertificateDetails logging
 	buf.Reset()
@@ -703,26 +611,12 @@ func TestRealClient_Logging(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	output = buf.String()
-	if !strings.Contains(output, "getting certificate details") {
-		t.Errorf("Expected details log, got: %s", output)
-	}
-	if !strings.Contains(output, "successfully retrieved and cached certificate details") {
-		t.Errorf("Expected success details log, got: %s", output)
-	}
+	assertLogContains(t, &buf, []string{"getting certificate details", "successfully retrieved and cached certificate details"})
 
 	// Test InvalidateCache logging
 	buf.Reset()
 	client.InvalidateCache()
-
-	output = buf.String()
-	if !strings.Contains(output, "invalidating vault client cache") {
-		t.Errorf("Expected cache invalidation start log, got: %s", output)
-	}
-	if !strings.Contains(output, "cache invalidated successfully") {
-		t.Errorf("Expected cache invalidation success log, got: %s", output)
-	}
+	assertLogContains(t, &buf, []string{"invalidating vault client cache", "cache invalidated successfully"})
 }
 
 // TestRealClient_LoggingErrors tests that error logging works correctly

--- a/docker-compose.sonarqube.yml
+++ b/docker-compose.sonarqube.yml
@@ -8,7 +8,7 @@ services:
     container_name: vcv-sonarqube
     restart: unless-stopped
     ports:
-      - "9000:9000"
+      - "9001:9000"
     environment:
       # Disable Elasticsearch bootstrap checks so the container starts locally
       # without tuning vm.max_map_count on Docker Desktop / OrbStack.

--- a/sonar-projects/server.properties
+++ b/sonar-projects/server.properties
@@ -16,6 +16,7 @@ sonar.exclusions=\
   **/graphify-*/**,\
   **/node_modules/**,\
   **/dist/**,\
+  **/web/**,\
   **/.DS_Store,\
   **/coverage.out
 

--- a/tools/sonar-bootstrap.sh
+++ b/tools/sonar-bootstrap.sh
@@ -11,7 +11,7 @@
 
 set -u
 
-SONAR_URL="http://localhost:9000"
+SONAR_URL="http://localhost:9001"
 ADMIN_USER="admin"
 DEFAULT_PASS="admin"
 TOKEN_NAME="vcv-local"

--- a/tools/sonar-query.py
+++ b/tools/sonar-query.py
@@ -13,7 +13,7 @@ Usage:
     python3 tools/sonar-query.py file <project-key> <file-path>
 
 Credentials are read from .sonar/admin-password (created by make sonar-bootstrap).
-Override the URL with SONAR_URL env var (default http://localhost:9000).
+Override the URL with SONAR_URL env var (default http://localhost:9001).
 """
 import argparse
 import json
@@ -24,7 +24,7 @@ import urllib.parse
 import base64
 
 
-SONAR_URL = os.environ.get("SONAR_URL", "http://localhost:9000")
+SONAR_URL = os.environ.get("SONAR_URL", "http://localhost:9001")
 PASS_FILE = ".sonar/admin-password"
 ADMIN_USER = "admin"
 

--- a/tools/sonar-scan.sh
+++ b/tools/sonar-scan.sh
@@ -11,7 +11,7 @@
 set -u
 
 TOKEN_FILE=".sonar/token"
-SONAR_URL="http://localhost:9000"
+SONAR_URL="http://localhost:9001"
 PROPERTIES_DIR="sonar-projects"
 
 # Map short names to properties files.


### PR DESCRIPTION
## Summary
- Refactor high-cognitive-complexity functions (go:S3776) across vault clients, middleware, logger, i18n, metrics collectors, admin/cert/config handlers, and `main.go` (buildRouter deps grouped into a struct for go:S107)
- Extract duplicated string literals into constants / shared helpers (go:S1192), including the certificate parse error format
- Document intentional no-op methods on `DisabledClient` (go:S1186)
- Simplify complex test functions and update Sonar tooling config (`sonar-projects/server.properties`, scan/bootstrap/query scripts)

No behavior change intended — pure refactoring to satisfy SonarQube rules.

#### Test plan
- [x] `make test-offline` (Go unit tests, offline)
- [x] `make go-lint-full`
- [x] `make sonar-scan` shows resolved findings

Generated with [Devin](https://devin.ai)